### PR TITLE
feat: v0.9.0 Phase 5 — compliance YAML + ML pipeline migration

### DIFF
--- a/ml/data/attack_data_pipeline.py
+++ b/ml/data/attack_data_pipeline.py
@@ -7,10 +7,12 @@ capture real attack data.
 """
 
 import json
+import re
+import shutil
 import time
 import hashlib
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Tuple
 from dataclasses import dataclass, asdict, field
@@ -21,6 +23,127 @@ from collections import defaultdict
 import threading
 from queue import Queue
 import logging
+
+
+# ---------------------------------------------------------------------------
+# v0.9.0 outcome taxonomy + bandit reward filter
+# ---------------------------------------------------------------------------
+
+# Outcome values stored in the attacks.outcome column. Mirrors the Go-side
+# common.AttackOutcome enum. The bandit reward filter excludes "skipped"
+# because skipped runs reflect engine/capability state, not target behavior,
+# and including them in reward aggregation would bias the bandit toward
+# (or against) targets that simply lack capabilities.
+OUTCOME_SUCCESS = "success"
+OUTCOME_REFUSED = "refused"
+OUTCOME_SKIPPED = "skipped"
+
+# BANDIT_REWARD_OUTCOMES is the canonical set of outcomes that count toward
+# bandit reward aggregation. Skipped is NOT here — see docstring above.
+BANDIT_REWARD_OUTCOMES = (OUTCOME_SUCCESS, OUTCOME_REFUSED)
+
+# Pattern matched against metadata keys for credential redaction. Case-
+# insensitive substring match; values for matching keys become "[REDACTED]"
+# before storage. Per the v0.9.0 plan security review.
+_SENSITIVE_KEY_PATTERN = re.compile(r"(?i)(key|token|secret|password|auth)")
+_REDACTED_PLACEHOLDER = "[REDACTED]"
+
+
+def _redact_sensitive_keys(obj: Any) -> Any:
+    """Return a deep copy of obj with values scrubbed wherever a string key
+    matches _SENSITIVE_KEY_PATTERN. Non-dict / non-list inputs are returned
+    unchanged. Used by the storage path to prevent operator-supplied
+    Metadata from leaking credentials into the analytics DB.
+
+    Examples:
+        >>> _redact_sensitive_keys({"api_key": "sk-1234", "model": "gpt-4"})
+        {'api_key': '[REDACTED]', 'model': 'gpt-4'}
+        >>> _redact_sensitive_keys({"params": {"auth_token": "x"}})
+        {'params': {'auth_token': '[REDACTED]'}}
+    """
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if isinstance(k, str) and _SENSITIVE_KEY_PATTERN.search(k):
+                out[k] = _REDACTED_PLACEHOLDER
+            else:
+                out[k] = _redact_sensitive_keys(v)
+        return out
+    if isinstance(obj, list):
+        return [_redact_sensitive_keys(v) for v in obj]
+    return obj
+
+
+def _migrate_v090(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Idempotent v0.9.0 schema migration for the attacks table.
+
+    Adds the `outcome` and `parent_run_id` columns + supporting partial
+    indexes. Backs up the database to {db_path}.bak.{UTC-timestamp} on the
+    first run that detects either column is missing. Subsequent runs are
+    no-ops (PRAGMA table_info reports the columns; ALTER TABLE is skipped;
+    CREATE INDEX guards on IF NOT EXISTS).
+
+    Backfill rule for legacy rows: outcome = 'success' iff status = 'success',
+    else 'refused'. Pre-v0.9.0 data has no third state to recover.
+
+    The migration is also safe to call on a fresh DB created by
+    _init_database (which now includes the columns from the start) — both
+    ALTER TABLE branches are skipped and only the indexes are created.
+    """
+    cur = conn.cursor()
+    cols = {r[1] for r in cur.execute("PRAGMA table_info(attacks)").fetchall()}
+    needs_alter = "outcome" not in cols or "parent_run_id" not in cols
+
+    # Only back up when we're about to actually mutate the schema.
+    if needs_alter and db_path.exists():
+        # timezone-aware UTC; .utcnow() is deprecated in Python 3.12+.
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup = db_path.with_suffix(db_path.suffix + f".bak.{ts}")
+        try:
+            shutil.copy2(db_path, backup)
+            logger.info("v0.9.0 migration: backed up %s → %s", db_path, backup)
+        except OSError as e:
+            logger.warning("v0.9.0 migration: backup failed (%s); proceeding anyway", e)
+
+    conn.execute("PRAGMA journal_mode=WAL;")
+
+    pre_count_row = cur.execute("SELECT COUNT(*) FROM attacks").fetchone()
+    pre_count = pre_count_row[0] if pre_count_row else 0
+
+    with conn:  # BEGIN IMMEDIATE … COMMIT
+        if "outcome" not in cols:
+            conn.execute("ALTER TABLE attacks ADD COLUMN outcome TEXT")
+        if "parent_run_id" not in cols:
+            conn.execute("ALTER TABLE attacks ADD COLUMN parent_run_id TEXT")
+
+    # Partial indexes — IF NOT EXISTS makes this idempotent across runs.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_attacks_outcome "
+        "ON attacks(outcome) WHERE outcome IS NOT NULL"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_attacks_parent_run_id "
+        "ON attacks(parent_run_id) WHERE parent_run_id IS NOT NULL"
+    )
+
+    post_cols = {r[1] for r in cur.execute("PRAGMA table_info(attacks)").fetchall()}
+    assert {"outcome", "parent_run_id"} <= post_cols, (
+        f"v0.9.0 migration failed: post-migration columns {post_cols} missing outcome/parent_run_id"
+    )
+    post_count = cur.execute("SELECT COUNT(*) FROM attacks").fetchone()[0]
+    assert post_count == pre_count, (
+        f"v0.9.0 migration row-count drift: pre={pre_count} post={post_count}"
+    )
+
+    # Backfill legacy rows once. WHERE outcome IS NULL keeps this idempotent
+    # and confined to pre-migration rows.
+    conn.execute(
+        "UPDATE attacks "
+        "SET outcome = CASE WHEN status = 'success' THEN ? ELSE ? END "
+        "WHERE outcome IS NULL",
+        (OUTCOME_SUCCESS, OUTCOME_REFUSED),
+    )
+    conn.commit()
 
 
 # Configure logging
@@ -122,10 +245,16 @@ class AttackDataPipeline:
         self.feature_extractors = self._init_feature_extractors()
         
     def _init_database(self):
-        """Initialize SQLite database for attack data"""
+        """Initialize SQLite database for attack data.
+
+        Fresh databases get the full v0.9.0 schema including outcome and
+        parent_run_id from CREATE TABLE. Pre-v0.9.0 databases that already
+        exist on disk are upgraded by _migrate_v090, which is idempotent
+        (safe to call on fresh DBs too — both ALTER branches no-op).
+        """
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
-        
+
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS attacks (
                 attack_id TEXT PRIMARY KEY,
@@ -147,17 +276,25 @@ class AttackDataPipeline:
                 user_id TEXT,
                 campaign_id TEXT,
                 features TEXT,
+                outcome TEXT,
+                parent_run_id TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP
             )
         ''')
-        
+
         # Create indices for common queries
         cursor.execute('CREATE INDEX IF NOT EXISTS idx_timestamp ON attacks(timestamp)')
         cursor.execute('CREATE INDEX IF NOT EXISTS idx_attack_type ON attacks(attack_type)')
         cursor.execute('CREATE INDEX IF NOT EXISTS idx_status ON attacks(status)')
         cursor.execute('CREATE INDEX IF NOT EXISTS idx_target_model ON attacks(target_model)')
-        
+
         conn.commit()
+
+        # Apply the v0.9.0 migration. Idempotent: on fresh DBs the columns
+        # already exist (both ALTER branches no-op) and only the partial
+        # indexes are created.
+        _migrate_v090(conn, self.db_path)
+
         conn.close()
         
     def _init_feature_extractors(self) -> Dict[str, Any]:
@@ -386,14 +523,22 @@ class AttackDataPipeline:
         cursor = conn.cursor()
         
         try:
+            # Credential redaction: scrub keys matching the sensitive-key
+            # pattern in technique_params and features before serialization.
+            # Per v0.9.0 plan security review — operator-supplied Metadata
+            # frequently leaks API keys / OAuth tokens / session bearers when
+            # captured verbatim into analytics.
+            safe_params = _redact_sensitive_keys(processed_data['technique_params'])
+            safe_features = _redact_sensitive_keys(processed_data['features'])
+
             cursor.execute('''
                 INSERT OR REPLACE INTO attacks (
                     attack_id, timestamp, attack_type, target_model, provider,
                     payload, technique_params, obfuscation_level, status,
                     response, response_time, tokens_used, success_indicators,
                     detection_score, semantic_similarity, session_id, user_id,
-                    campaign_id, features
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    campaign_id, features, outcome, parent_run_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', (
                 processed_data['attack_id'],
                 processed_data['timestamp'],
@@ -401,7 +546,7 @@ class AttackDataPipeline:
                 processed_data['target_model'],
                 processed_data['provider'],
                 processed_data['payload'],
-                json.dumps(processed_data['technique_params']),
+                json.dumps(safe_params),
                 processed_data['obfuscation_level'],
                 processed_data['status'],
                 processed_data['response'],
@@ -413,7 +558,9 @@ class AttackDataPipeline:
                 processed_data.get('session_id'),
                 processed_data.get('user_id'),
                 processed_data.get('campaign_id'),
-                json.dumps(processed_data['features'])
+                json.dumps(safe_features),
+                processed_data.get('outcome'),
+                processed_data.get('parent_run_id'),
             ))
             
             conn.commit()
@@ -423,7 +570,96 @@ class AttackDataPipeline:
             conn.rollback()
         finally:
             conn.close()
-    
+
+    def get_bandit_rewards(
+        self,
+        target_model: Optional[str] = None,
+        attack_type: Optional[str] = None,
+        limit: int = 1000,
+    ) -> Dict[str, Any]:
+        """Bandit reward aggregation excluding skipped outcomes.
+
+        Bandits select arms (provider/model/technique) based on observed
+        reward — but rows with outcome='skipped' reflect engine or
+        capability state (missing ImageProvider, signature-gated trace,
+        budget exceeded), NOT target behavior. Including them in reward
+        aggregation biases the bandit toward (or against) targets that
+        simply lack capabilities. The v0.9.0 plan's central correctness
+        invariant is `WHERE outcome IN ('success', 'refused')` everywhere
+        bandit reward is computed.
+
+        This method is the canonical single point of truth for that
+        filter. Other code that aggregates reward should call here rather
+        than write its own WHERE clause.
+
+        Args:
+            target_model: Optional filter on target_model column.
+            attack_type: Optional filter on attack_type column.
+            limit: Max rows to consider (most recent first).
+
+        Returns:
+            {
+                "success_rate": float in [0, 1] over qualifying rows,
+                "sample_count": int — qualifying rows seen,
+                "skipped_count": int — for transparency / debug,
+                "outcomes": dict counting each outcome value,
+            }
+            sample_count == 0 ⟹ success_rate == 0.0 (no rewards yet).
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.cursor()
+
+            where_clauses = []
+            params: List[Any] = []
+            if target_model is not None:
+                where_clauses.append("target_model = ?")
+                params.append(target_model)
+            if attack_type is not None:
+                where_clauses.append("attack_type = ?")
+                params.append(attack_type)
+            where_sql = (" AND ".join(where_clauses)) if where_clauses else "1=1"
+
+            # Aggregate including skipped so we can report skipped_count
+            # for transparency. The reward SQL itself filters skipped via
+            # CASE WHEN — equivalent to a WHERE outcome IN (...) but lets
+            # us count skipped in the same pass.
+            placeholders = ",".join("?" * len(BANDIT_REWARD_OUTCOMES))
+            sql = f"""
+                SELECT outcome, COUNT(*) FROM (
+                    SELECT outcome
+                    FROM attacks
+                    WHERE {where_sql}
+                    ORDER BY timestamp DESC
+                    LIMIT ?
+                )
+                GROUP BY outcome
+            """
+            cursor.execute(sql, (*params, limit))
+            outcomes: Dict[str, int] = {}
+            for row in cursor.fetchall():
+                key = row[0] or "(null)"
+                outcomes[key] = row[1]
+
+            # Reward population: success + refused. Skipped explicitly excluded.
+            rewardable = outcomes.get(OUTCOME_SUCCESS, 0) + outcomes.get(OUTCOME_REFUSED, 0)
+            success_count = outcomes.get(OUTCOME_SUCCESS, 0)
+            skipped_count = outcomes.get(OUTCOME_SKIPPED, 0)
+            success_rate = (success_count / rewardable) if rewardable > 0 else 0.0
+
+            # Silence the unused-placeholders warning the linter would
+            # otherwise issue if the parametric IN clause is unused.
+            _ = placeholders
+
+            return {
+                "success_rate": success_rate,
+                "sample_count": rewardable,
+                "skipped_count": skipped_count,
+                "outcomes": outcomes,
+            }
+        finally:
+            conn.close()
+
     def _get_recent_attack_stats(self, target_model: str, attack_type: str) -> Dict[str, float]:
         """Get statistics for recent attacks"""
         conn = sqlite3.connect(self.db_path)

--- a/ml/data/attack_data_pipeline.py
+++ b/ml/data/attack_data_pipeline.py
@@ -8,7 +8,6 @@ capture real attack data.
 
 import json
 import re
-import shutil
 import time
 import hashlib
 import sqlite3
@@ -95,14 +94,28 @@ def _migrate_v090(conn: sqlite3.Connection, db_path: Path) -> None:
     needs_alter = "outcome" not in cols or "parent_run_id" not in cols
 
     # Only back up when we're about to actually mutate the schema.
+    #
+    # Use SQLite's Online Backup API (Connection.backup) rather than a
+    # filesystem copy. In WAL mode (which we enable below for the
+    # attacks DB), recently-committed transactions can live in
+    # `<db>-wal` and `<db>-shm` sidecar files; copying only the main
+    # `.db` file produces an inconsistent snapshot where commits made
+    # via WAL haven't been checkpointed into the main file. SQLite's
+    # docs explicitly warn against filesystem copies for this reason.
+    # The Online Backup API handles WAL state correctly by walking the
+    # database page-by-page through the source connection.
     if needs_alter and db_path.exists():
         # timezone-aware UTC; .utcnow() is deprecated in Python 3.12+.
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         backup = db_path.with_suffix(db_path.suffix + f".bak.{ts}")
         try:
-            shutil.copy2(db_path, backup)
+            dst = sqlite3.connect(str(backup))
+            try:
+                conn.backup(dst)
+            finally:
+                dst.close()
             logger.info("v0.9.0 migration: backed up %s → %s", db_path, backup)
-        except OSError as e:
+        except sqlite3.Error as e:
             logger.warning("v0.9.0 migration: backup failed (%s); proceeding anyway", e)
 
     conn.execute("PRAGMA journal_mode=WAL;")
@@ -620,36 +633,53 @@ class AttackDataPipeline:
                 params.append(attack_type)
             where_sql = (" AND ".join(where_clauses)) if where_clauses else "1=1"
 
-            # Aggregate including skipped so we can report skipped_count
-            # for transparency. The reward SQL itself filters skipped via
-            # CASE WHEN — equivalent to a WHERE outcome IN (...) but lets
-            # us count skipped in the same pass.
+            # Reward query — apply the rewardable-outcome filter INSIDE
+            # the LIMIT-bound subquery so the window contains the most
+            # recent `limit` *rewardable* rows. If we filtered after
+            # LIMIT, a burst of recent skipped rows would displace
+            # rewardables out of the window and shrink sample_count
+            # without bound. The partial index `idx_attacks_outcome`
+            # also only helps when the IN-clause is in the SQL, not
+            # post-fetch in Python.
             placeholders = ",".join("?" * len(BANDIT_REWARD_OUTCOMES))
-            sql = f"""
+            reward_sql = f"""
                 SELECT outcome, COUNT(*) FROM (
                     SELECT outcome
                     FROM attacks
-                    WHERE {where_sql}
+                    WHERE {where_sql} AND outcome IN ({placeholders})
                     ORDER BY timestamp DESC
                     LIMIT ?
                 )
                 GROUP BY outcome
             """
-            cursor.execute(sql, (*params, limit))
+            cursor.execute(reward_sql, (*params, *BANDIT_REWARD_OUTCOMES, limit))
             outcomes: Dict[str, int] = {}
             for row in cursor.fetchall():
                 key = row[0] or "(null)"
                 outcomes[key] = row[1]
 
+            # Skipped count — separate query because we just filtered
+            # them OUT of the reward population. Bounded by the same
+            # `limit` window so the displayed counts are temporally
+            # comparable to the reward sample.
+            skipped_sql = f"""
+                SELECT COUNT(*) FROM (
+                    SELECT 1
+                    FROM attacks
+                    WHERE {where_sql} AND outcome = ?
+                    ORDER BY timestamp DESC
+                    LIMIT ?
+                )
+            """
+            cursor.execute(skipped_sql, (*params, OUTCOME_SKIPPED, limit))
+            skipped_row = cursor.fetchone()
+            skipped_count = skipped_row[0] if skipped_row else 0
+            outcomes[OUTCOME_SKIPPED] = skipped_count
+
             # Reward population: success + refused. Skipped explicitly excluded.
             rewardable = outcomes.get(OUTCOME_SUCCESS, 0) + outcomes.get(OUTCOME_REFUSED, 0)
             success_count = outcomes.get(OUTCOME_SUCCESS, 0)
-            skipped_count = outcomes.get(OUTCOME_SKIPPED, 0)
             success_rate = (success_count / rewardable) if rewardable > 0 else 0.0
-
-            # Silence the unused-placeholders warning the linter would
-            # otherwise issue if the parametric IN clause is unused.
-            _ = placeholders
 
             return {
                 "success_rate": success_rate,

--- a/src/compliance/owasp_agentic.go
+++ b/src/compliance/owasp_agentic.go
@@ -217,6 +217,18 @@ func TechniqueToAgenticCategories(techniqueID string) []OWASPAgenticCategory {
 		"cot_phishing_reasoning":     {TrustExploitation},
 		"deceptive_alignment":        {TrustExploitation, RogueAgents},
 		"autonomous_jailbreak":       {RogueAgents},
+		// v0.9.0 additions — keep in sync with templates/owasp_agentic_2026.yaml
+		// technique_index. The cmd/owasp-gen tool produces the equivalent
+		// generated map; v0.10.0 will switch the runtime lookup to the
+		// generated map and delete this hand-written block.
+		"h_cot":                      {AgentGoalHijack},
+		"siva":                       {AgentGoalHijack},
+		"vsh":                        {AgentGoalHijack},
+		"jbfuzz":                     {AgentGoalHijack},
+		"persona_evolve":             {AgentGoalHijack, TrustExploitation},
+		"minja":                      {MemoryPoisoning},
+		"memorygraft":                {MemoryPoisoning, RogueAgents},
+		"injecmem":                   {MemoryPoisoning},
 	}
 	return index[techniqueID]
 }

--- a/templates/owasp_agentic_2026.yaml
+++ b/templates/owasp_agentic_2026.yaml
@@ -55,6 +55,21 @@ categories:
       - id: multilingual_audio_translation
         priority: medium
         notes: "Non-English audio bypasses goal protection"
+      - id: h_cot
+        priority: critical
+        notes: "Hijacks reasoning model's safety-recognition step (98%→2% refusal on o1/o3/R1, arXiv 2502.12893)"
+      - id: siva
+        priority: high
+        notes: "Split-image multimodal attack exploits cross-fragment visual reasoning (arXiv 2602.08136)"
+      - id: vsh
+        priority: high
+        notes: "Virtual scenario hypnosis: narrative-fiction frame paired with scene image (ScienceDirect S0031320325010520)"
+      - id: jbfuzz
+        priority: high
+        notes: "Black-box mutation/feedback fuzzer; 99% ASR in ~60s on the original benchmark (arXiv 2503.08990)"
+      - id: persona_evolve
+        priority: high
+        notes: "Genetic-algorithm persona modulation; 50-70% refusal reduction (arXiv 2507.22171)"
     test_cases:
       - id: ASI01-TC01
         title: "Indirect prompt injection via retrieved document"
@@ -283,6 +298,15 @@ categories:
       - id: agent_config_rewrite
         priority: critical
         notes: "Rewrite agent config for persistent memory poisoning"
+      - id: minja
+        priority: critical
+        notes: "Query-bound memory injection verified within the same session (arXiv 2503.03704)"
+      - id: memorygraft
+        priority: critical
+        notes: "Episodic-experience implants verified across a fresh session via SessionProvider.NewSession (arXiv 2512.16962)"
+      - id: injecmem
+        priority: high
+        notes: "Single-interaction targeted implant with deferred trigger phrase (OpenReview QVX6hcJ2um)"
     test_cases:
       - id: ASI06-TC01
         title: "RAG data poisoning"
@@ -412,6 +436,9 @@ categories:
       - id: deceptive_alignment
         priority: high
         notes: "Agent appears aligned but acts against user interests"
+      - id: persona_evolve
+        priority: high
+        notes: "GA-evolved personas exploit role-based trust framing (arXiv 2507.22171)"
     test_cases:
       - id: ASI09-TC01
         title: "Implicit trust assumption abuse"
@@ -457,6 +484,9 @@ categories:
       - id: agent_config_rewrite
         priority: high
         notes: "Self-modifying agent that rewrites its own configuration"
+      - id: memorygraft
+        priority: high
+        notes: "Episodic implants persist across sessions and shape future autonomous decisions (arXiv 2512.16962)"
     test_cases:
       - id: ASI10-TC01
         title: "Deceptive alignment detection"
@@ -517,3 +547,12 @@ technique_index:
   cot_phishing_reasoning: [ASI09]
   deceptive_alignment: [ASI09, ASI10]
   autonomous_jailbreak: [ASI10]
+  # v0.9.0 additions
+  h_cot: [ASI01]
+  siva: [ASI01]
+  vsh: [ASI01]
+  jbfuzz: [ASI01]
+  persona_evolve: [ASI01, ASI09]
+  minja: [ASI06]
+  memorygraft: [ASI06, ASI10]
+  injecmem: [ASI06]

--- a/tests/test_attack_data_pipeline.py
+++ b/tests/test_attack_data_pipeline.py
@@ -371,6 +371,98 @@ class TestBanditRewardFilter(unittest.TestCase):
         # And the central rule: skipped is NOT in the reward set.
         self.assertNotIn(OUTCOME_SKIPPED, BANDIT_REWARD_OUTCOMES)
 
+    def test_recent_skipped_burst_does_not_displace_rewardables(self):
+        """Regression: when the newest rows are all skipped, the reward
+        population must still contain the most recent `limit` rewardable
+        rows. A naive implementation that LIMITs first and filters
+        skipped afterward will shrink sample_count toward zero — exactly
+        the bug CodeRabbit caught on PR #163.
+        """
+        # Inline import to avoid coupling the test to pandas/numpy import
+        # order at module load (the pipeline class brings them in).
+        from ml.data.attack_data_pipeline import AttackDataPipeline
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            p = AttackDataPipeline({"storage_path": tmpdir})
+
+            # Insert 5 rewardable rows (oldest first), then 3 skipped rows
+            # (newest). Limit=5 — a buggy implementation would see 3
+            # skipped + 2 rewardable in its window; a correct one sees
+            # all 5 rewardable.
+            conn = sqlite3.connect(p.db_path)
+            try:
+                base = "2026-01-01T00:00:0"
+                for i, (status, outcome) in enumerate([
+                    ("success", OUTCOME_SUCCESS),
+                    ("blocked", OUTCOME_REFUSED),
+                    ("success", OUTCOME_SUCCESS),
+                    ("blocked", OUTCOME_REFUSED),
+                    ("success", OUTCOME_SUCCESS),
+                ]):
+                    conn.execute(
+                        """INSERT INTO attacks
+                           (attack_id, timestamp, attack_type, target_model,
+                            provider, payload, status, response_time, tokens_used,
+                            technique_params, obfuscation_level, response,
+                            success_indicators, detection_score, semantic_similarity,
+                            features, outcome)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        (f"r{i}", f"{base}{i}", "t", "m", "p", "x", status,
+                         0.0, 0, "{}", 0.0, "", "[]", 0.0, 0.0, "{}", outcome),
+                    )
+                # Newer rows: all skipped.
+                for i, _ in enumerate(range(3)):
+                    conn.execute(
+                        """INSERT INTO attacks
+                           (attack_id, timestamp, attack_type, target_model,
+                            provider, payload, status, response_time, tokens_used,
+                            technique_params, obfuscation_level, response,
+                            success_indicators, detection_score, semantic_similarity,
+                            features, outcome)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        (f"k{i}", f"2026-01-02T00:00:0{i}", "t", "m", "p",
+                         "x", "skipped", 0.0, 0, "{}", 0.0, "", "[]", 0.0,
+                         0.0, "{}", OUTCOME_SKIPPED),
+                    )
+                conn.commit()
+            finally:
+                conn.close()
+
+            # limit=5: with the bug, sample_count would be 2 (3 skipped
+            # displaced 3 rewardables); with the fix, sample_count is 5.
+            result = p.get_bandit_rewards(limit=5)
+            self.assertEqual(
+                result["sample_count"], 5,
+                "recent skipped burst displaced rewardables out of the "
+                "limit window — reward filter is applied AFTER LIMIT "
+                f"instead of inside the LIMIT subquery: {result}",
+            )
+            self.assertEqual(
+                result["outcomes"].get(OUTCOME_SUCCESS), 3,
+                f"success count drift: {result}",
+            )
+            self.assertEqual(
+                result["outcomes"].get(OUTCOME_REFUSED), 2,
+                f"refused count drift: {result}",
+            )
+            self.assertEqual(
+                result["skipped_count"], 3,
+                "skipped_count must be reported separately (not in reward sample)",
+            )
+            # success_rate over rewardables: 3/5 = 0.6.
+            self.assertAlmostEqual(result["success_rate"], 0.6)
+        finally:
+            for p in Path(tmpdir).rglob("*"):
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+            try:
+                os.rmdir(tmpdir)
+            except OSError:
+                pass
+
     def test_filter_excludes_skipped_at_sql_level(self):
         # Build a tiny migrated DB with one of each outcome; verify a
         # filter query returns only success + refused.

--- a/tests/test_attack_data_pipeline.py
+++ b/tests/test_attack_data_pipeline.py
@@ -1,0 +1,423 @@
+"""Tests for ml.data.attack_data_pipeline — v0.9.0 migration / redaction /
+bandit reward filter.
+
+Run via:
+    python -m pytest tests/test_attack_data_pipeline.py -v
+or:
+    python tests/test_attack_data_pipeline.py    # unittest fallback
+
+No third-party deps beyond the pipeline's own (numpy / pandas, which the
+top-level module imports). Tests use sqlite3 directly and tempfile for
+isolated databases.
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Make project root importable when tests/ is invoked directly.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ml.data.attack_data_pipeline import (  # noqa: E402
+    BANDIT_REWARD_OUTCOMES,
+    OUTCOME_REFUSED,
+    OUTCOME_SKIPPED,
+    OUTCOME_SUCCESS,
+    _migrate_v090,
+    _redact_sensitive_keys,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_legacy_db(path: Path, rows):
+    """Create a v0.8.0-shaped attacks table at `path` (no outcome /
+    parent_run_id columns) and insert `rows` (each a dict with keys
+    matching the legacy column names)."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE attacks (
+            attack_id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            attack_type TEXT NOT NULL,
+            target_model TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            technique_params TEXT,
+            obfuscation_level REAL,
+            status TEXT NOT NULL,
+            response TEXT,
+            response_time REAL,
+            tokens_used INTEGER,
+            success_indicators TEXT,
+            detection_score REAL,
+            semantic_similarity REAL,
+            session_id TEXT,
+            user_id TEXT,
+            campaign_id TEXT,
+            features TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    for r in rows:
+        conn.execute(
+            """
+            INSERT INTO attacks (
+                attack_id, timestamp, attack_type, target_model, provider,
+                payload, status, response_time, tokens_used,
+                technique_params, obfuscation_level, response,
+                success_indicators, detection_score, semantic_similarity, features
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                r["attack_id"],
+                r["timestamp"],
+                r["attack_type"],
+                r["target_model"],
+                r["provider"],
+                r["payload"],
+                r["status"],
+                r.get("response_time", 0.0),
+                r.get("tokens_used", 0),
+                "{}",
+                0.0,
+                "",
+                "[]",
+                0.0,
+                0.0,
+                "{}",
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Credential redaction
+# ---------------------------------------------------------------------------
+
+
+class TestRedactSensitiveKeys(unittest.TestCase):
+    def test_top_level_key_match(self):
+        out = _redact_sensitive_keys({"api_key": "sk-1234", "model": "gpt-4"})
+        self.assertEqual(out["api_key"], "[REDACTED]")
+        self.assertEqual(out["model"], "gpt-4")
+
+    def test_case_insensitive(self):
+        out = _redact_sensitive_keys({"API_KEY": "x", "Auth_Token": "y", "name": "z"})
+        self.assertEqual(out["API_KEY"], "[REDACTED]")
+        self.assertEqual(out["Auth_Token"], "[REDACTED]")
+        self.assertEqual(out["name"], "z")
+
+    def test_substring_match(self):
+        out = _redact_sensitive_keys(
+            {
+                "secret_phrase": "x",
+                "user_password_hash": "y",
+                "session_auth_id": "z",
+                "ordinary_field": "ok",
+            }
+        )
+        self.assertEqual(out["secret_phrase"], "[REDACTED]")
+        self.assertEqual(out["user_password_hash"], "[REDACTED]")
+        self.assertEqual(out["session_auth_id"], "[REDACTED]")
+        self.assertEqual(out["ordinary_field"], "ok")
+
+    def test_nested_dict(self):
+        out = _redact_sensitive_keys(
+            {"params": {"auth_token": "x", "endpoint": "https://example.com"}}
+        )
+        self.assertEqual(out["params"]["auth_token"], "[REDACTED]")
+        self.assertEqual(out["params"]["endpoint"], "https://example.com")
+
+    def test_list_of_dicts(self):
+        out = _redact_sensitive_keys(
+            [{"key": "v1"}, {"name": "v2"}, {"password": "v3"}]
+        )
+        self.assertEqual(out[0]["key"], "[REDACTED]")
+        self.assertEqual(out[1]["name"], "v2")
+        self.assertEqual(out[2]["password"], "[REDACTED]")
+
+    def test_passthrough_for_non_dict_non_list(self):
+        # Strings, ints, None, etc. pass through unchanged.
+        for v in ["secret_string_value", 42, None, 3.14, True]:
+            self.assertEqual(_redact_sensitive_keys(v), v)
+
+    def test_does_not_mutate_input(self):
+        original = {"api_key": "sk-1234", "model": "gpt-4"}
+        snapshot = dict(original)
+        _ = _redact_sensitive_keys(original)
+        self.assertEqual(original, snapshot, "input dict was mutated")
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateV090(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = Path(self.tmpdir) / "attacks.db"
+
+    def tearDown(self):
+        # Best-effort cleanup; tests may create backup files too.
+        for p in Path(self.tmpdir).iterdir():
+            try:
+                p.unlink()
+            except OSError:
+                pass
+        os.rmdir(self.tmpdir)
+
+    def test_adds_outcome_and_parent_run_id_columns(self):
+        _create_legacy_db(self.db_path, [])
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(attacks)").fetchall()}
+        finally:
+            conn.close()
+        self.assertIn("outcome", cols)
+        self.assertIn("parent_run_id", cols)
+
+    def test_backfills_outcome_from_status(self):
+        rows = [
+            {
+                "attack_id": "a1",
+                "timestamp": "2026-01-01T00:00:00",
+                "attack_type": "t",
+                "target_model": "m",
+                "provider": "p",
+                "payload": "x",
+                "status": "success",
+            },
+            {
+                "attack_id": "a2",
+                "timestamp": "2026-01-01T00:00:00",
+                "attack_type": "t",
+                "target_model": "m",
+                "provider": "p",
+                "payload": "x",
+                "status": "detected",
+            },
+            {
+                "attack_id": "a3",
+                "timestamp": "2026-01-01T00:00:00",
+                "attack_type": "t",
+                "target_model": "m",
+                "provider": "p",
+                "payload": "x",
+                "status": "blocked",
+            },
+        ]
+        _create_legacy_db(self.db_path, rows)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)
+            outcomes = dict(conn.execute("SELECT attack_id, outcome FROM attacks").fetchall())
+        finally:
+            conn.close()
+        # status='success' → 'success'; everything else → 'refused'.
+        self.assertEqual(outcomes["a1"], OUTCOME_SUCCESS)
+        self.assertEqual(outcomes["a2"], OUTCOME_REFUSED)
+        self.assertEqual(outcomes["a3"], OUTCOME_REFUSED)
+
+    def test_idempotent_on_second_run(self):
+        # Pre-migration row counts and post-migration columns must remain
+        # stable across repeated invocations.
+        rows = [
+            {
+                "attack_id": f"a{i}",
+                "timestamp": "2026-01-01T00:00:00",
+                "attack_type": "t",
+                "target_model": "m",
+                "provider": "p",
+                "payload": "x",
+                "status": "success" if i % 2 == 0 else "blocked",
+            }
+            for i in range(5)
+        ]
+        _create_legacy_db(self.db_path, rows)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)
+            first_outcomes = dict(conn.execute("SELECT attack_id, outcome FROM attacks").fetchall())
+            first_count = conn.execute("SELECT COUNT(*) FROM attacks").fetchone()[0]
+            # Run a second time — must not change anything.
+            _migrate_v090(conn, self.db_path)
+            second_outcomes = dict(conn.execute("SELECT attack_id, outcome FROM attacks").fetchall())
+            second_count = conn.execute("SELECT COUNT(*) FROM attacks").fetchone()[0]
+        finally:
+            conn.close()
+        self.assertEqual(first_outcomes, second_outcomes, "second run changed outcomes")
+        self.assertEqual(first_count, second_count, "second run changed row count")
+
+    def test_does_not_overwrite_existing_outcome(self):
+        # Rows that already have an outcome value must keep it after a
+        # subsequent migration call.
+        _create_legacy_db(self.db_path, [
+            {
+                "attack_id": "a1",
+                "timestamp": "2026-01-01T00:00:00",
+                "attack_type": "t",
+                "target_model": "m",
+                "provider": "p",
+                "payload": "x",
+                "status": "blocked",
+            },
+        ])
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)
+            # Manually set the outcome to skipped for this row, then
+            # re-run migration — which should NOT reset our value.
+            conn.execute("UPDATE attacks SET outcome = ? WHERE attack_id = ?",
+                         (OUTCOME_SKIPPED, "a1"))
+            conn.commit()
+            _migrate_v090(conn, self.db_path)
+            outcome = conn.execute("SELECT outcome FROM attacks WHERE attack_id = ?",
+                                   ("a1",)).fetchone()[0]
+        finally:
+            conn.close()
+        self.assertEqual(outcome, OUTCOME_SKIPPED)
+
+    def test_creates_partial_indexes(self):
+        _create_legacy_db(self.db_path, [])
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)
+            indexes = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'attacks'"
+            ).fetchall()}
+        finally:
+            conn.close()
+        self.assertIn("idx_attacks_outcome", indexes)
+        self.assertIn("idx_attacks_parent_run_id", indexes)
+
+    def test_creates_backup_when_altering(self):
+        _create_legacy_db(self.db_path, [])
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)
+        finally:
+            conn.close()
+        # A .bak.{timestamp} sibling must exist.
+        backups = [
+            p for p in Path(self.tmpdir).iterdir()
+            if p.name.startswith("attacks.db.bak.")
+        ]
+        self.assertEqual(len(backups), 1, f"expected 1 backup; saw {[p.name for p in backups]}")
+
+    def test_no_backup_when_already_migrated(self):
+        # Running migration on a DB that already has the columns should
+        # NOT create a fresh backup (avoids backup-file proliferation).
+        _create_legacy_db(self.db_path, [])
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)  # First pass — backup created.
+        finally:
+            conn.close()
+
+        # Delete any backups so we can test the second-run no-backup path
+        # in isolation.
+        for p in Path(self.tmpdir).iterdir():
+            if p.name.startswith("attacks.db.bak."):
+                p.unlink()
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _migrate_v090(conn, self.db_path)  # Second pass — no backup expected.
+        finally:
+            conn.close()
+
+        backups = [
+            p for p in Path(self.tmpdir).iterdir()
+            if p.name.startswith("attacks.db.bak.")
+        ]
+        self.assertEqual(
+            len(backups), 0,
+            "second migration created an unnecessary backup",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bandit reward filter — exercised via direct SQL because instantiating the
+# full AttackDataPipeline brings in numpy/pandas/threading that aren't
+# necessary for testing the filter contract.
+# ---------------------------------------------------------------------------
+
+
+class TestBanditRewardFilter(unittest.TestCase):
+    """The bandit reward filter's central invariant is `outcome IN
+    ('success', 'refused')` — skipped is NEVER in the population. These
+    tests assert that invariant via the constants themselves (which the
+    pipeline method reads from) AND via a direct SQL query that mirrors
+    the method's filter."""
+
+    def test_canonical_constants(self):
+        # The constants are the contract. Anything that diverges is a bug.
+        self.assertEqual(BANDIT_REWARD_OUTCOMES, ("success", "refused"))
+        self.assertEqual(OUTCOME_SUCCESS, "success")
+        self.assertEqual(OUTCOME_REFUSED, "refused")
+        self.assertEqual(OUTCOME_SKIPPED, "skipped")
+        # And the central rule: skipped is NOT in the reward set.
+        self.assertNotIn(OUTCOME_SKIPPED, BANDIT_REWARD_OUTCOMES)
+
+    def test_filter_excludes_skipped_at_sql_level(self):
+        # Build a tiny migrated DB with one of each outcome; verify a
+        # filter query returns only success + refused.
+        tmpdir = tempfile.mkdtemp()
+        db_path = Path(tmpdir) / "attacks.db"
+        try:
+            rows = [
+                {"attack_id": "s1", "status": "success"},
+                {"attack_id": "r1", "status": "blocked"},
+                {"attack_id": "k1", "status": "success"},  # will become 'skipped'
+            ]
+            _create_legacy_db(db_path, [
+                {**r,
+                 "timestamp": "2026-01-01T00:00:00",
+                 "attack_type": "t",
+                 "target_model": "m",
+                 "provider": "p",
+                 "payload": "x"}
+                for r in rows
+            ])
+            conn = sqlite3.connect(db_path)
+            try:
+                _migrate_v090(conn, db_path)
+                # Override one row to skipped.
+                conn.execute("UPDATE attacks SET outcome = ? WHERE attack_id = ?",
+                             (OUTCOME_SKIPPED, "k1"))
+                conn.commit()
+
+                # The filter the pipeline uses.
+                placeholders = ",".join("?" * len(BANDIT_REWARD_OUTCOMES))
+                cursor = conn.execute(
+                    f"SELECT attack_id FROM attacks WHERE outcome IN ({placeholders})",
+                    BANDIT_REWARD_OUTCOMES,
+                )
+                ids = sorted(r[0] for r in cursor.fetchall())
+            finally:
+                conn.close()
+
+            self.assertEqual(ids, ["r1", "s1"], f"skipped row leaked into reward set: {ids}")
+        finally:
+            for p in Path(tmpdir).iterdir():
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+            os.rmdir(tmpdir)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes Phase 5 of the v0.9.0 plan. Two coordinated changes:
- **Compliance**: 8 new v0.9.0 attack technique entries in the OWASP Agentic 2026 YAML + matching hand-written map updates.
- **ML pipeline**: idempotent v0.9.0 schema migration (`outcome` + `parent_run_id`), credential redaction, and the canonical bandit reward filter that excludes skipped outcomes.

## OWASP Agentic 2026 mapping — 8 new technique entries

| ASI category | New technique entries |
|---|---|
| ASI01 — Agent Goal Hijack | `h_cot`, `siva`, `vsh`, `jbfuzz`, `persona_evolve` |
| ASI06 — Memory & Context Poisoning | `minja`, `memorygraft`, `injecmem` |
| ASI09 — Trust Exploitation | `persona_evolve` (synergistic with ASI01) |
| ASI10 — Rogue Agents | `memorygraft` (cross-session episodic implants) |

Plus the corresponding entries in the `technique_index` reverse-lookup. Verified by running `cmd/owasp-gen` against the updated YAML — emits the expected map entries for each new technique. The hand-written `TechniqueToAgenticCategories` in `src/compliance/owasp_agentic.go` is kept in sync (v0.9.0 plan: hand-written remains canonical for runtime; v0.10.0 switches to generated map).

## ML pipeline — three coordinated changes

### 1. `_migrate_v090(conn, db_path)` — idempotent schema migration

Adds `outcome` (TEXT) and `parent_run_id` (TEXT) columns to the `attacks` table. Backs up to `{db_path}.bak.{UTC-timestamp}` only on the first run that detects either column is missing — avoids backup proliferation on no-op invocations.

- WAL mode; `PRAGMA table_info` introspection; `ALTER TABLE` guarded by column-presence check.
- `IF NOT EXISTS` partial indexes (`idx_attacks_outcome`, `idx_attacks_parent_run_id`) that skip NULLs.
- Pre/post row-count assertion.
- One-time backfill: `outcome = CASE WHEN status='success' THEN 'success' ELSE 'refused' END WHERE outcome IS NULL`. Pre-v0.9.0 data has no third state to recover.
- Wired into `_init_database`. New DBs get the columns from `CREATE TABLE` and the migration no-ops on both `ALTER` branches.

### 2. Credential redaction — `_redact_sensitive_keys()`

Recursively scrubs dict keys matching `(?i)(key|token|secret|password|auth)` in `technique_params` and `features` before `INSERT`. Replaces the value with `"[REDACTED]"`. Per v0.9.0 plan security review: operator-supplied Metadata frequently leaks API keys / OAuth tokens / session bearers when captured verbatim into analytics.

### 3. `get_bandit_rewards()` — canonical reward aggregation

The v0.9.0 plan's central correctness rule for ML training is `WHERE outcome IN ('success', 'refused')` — skipped is **never** in the reward population. Skipped reflects engine/capability state (missing `ImageProvider`, signature-gated trace, budget exceeded), not target behavior, and including it biases the bandit toward (or against) targets that simply lack capabilities.

This method is the single point of truth for that filter:

```python
{
    "success_rate": float,    # over rows where outcome ∈ {success, refused}
    "sample_count": int,      # qualifying rows
    "skipped_count": int,     # for transparency / debug
    "outcomes": dict,         # full breakdown
}
```

The `OUTCOME_SUCCESS` / `OUTCOME_REFUSED` / `OUTCOME_SKIPPED` constants mirror the Go-side `common.AttackOutcome` enum exactly.

## Tests (16 new unittest cases, all passing)

Following the no-third-party-deps convention from `tests/test_template_loader.py`:

- **Redaction (7)** — top-level match, case-insensitive, substring match, nested dict, list of dicts, passthrough for primitives, no input mutation
- **Migration (7)** — adds the columns, backfills `outcome` from `status`, idempotent on second run, does not overwrite existing outcome values, creates partial indexes, creates backup only on first schema-altering run, no backup on already-migrated DB
- **Bandit reward filter (2)** — canonical constants invariant (`skipped` NOT in `BANDIT_REWARD_OUTCOMES`); SQL filter excludes skipped at the storage level

Tests use `sqlite3` directly + `tempfile` so they don't need pandas/numpy in the test path itself (the pipeline module imports them but the test boundary is at the helpers).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./src/compliance/... ./cmd/owasp-gen/...` — all pass (codegen still produces the expected entries against the updated YAML)
- [x] `python tests/test_attack_data_pipeline.py` — 16/16 pass
- [x] `python -W error::DeprecationWarning` — clean (`datetime.utcnow()` replaced with timezone-aware `now(timezone.utc)`)
- [x] Smoke: `AttackDataPipeline` instantiates with v0.9.0 schema; new DBs get `outcome` / `parent_run_id` from `CREATE TABLE`; partial indexes created

## What's NOT in this PR

- **Phase 6** — CHANGELOG / CLAUDE.md updates / integration smoke tests follow.
- **Switch runtime to generated compliance map** — v0.10.0 per the original plan; this PR keeps both side-by-side.
- **Provider adapter `ReasoningProvider` / `ImageProvider` implementations** — Phase 1 follow-up; Phase 3 modules continue to emit `SkipMissingCapability` against current adapters.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attack outcome tracking with three categorization levels
  * Introduced new reward computation method for attack evaluations
  * Extended OWASP Agentic attack technique support with 8 new techniques

* **Bug Fixes**
  * Implemented automatic redaction of sensitive credentials in stored data

* **Chores**
  * Updated data storage schema with outcome and parent run tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->