### PR TITLE
fix(provider/core): retry loop must surface ctx cancellation, not lastErr

### DIFF
--- a/src/provider/core/retry.go
+++ b/src/provider/core/retry.go
@@ -72,10 +72,16 @@ func RetryableQuery[T any](ctx context.Context, policy RetryPolicy, fn func(ctx 
 		// Check ctx cancellation before each attempt — including the first.
 		// fn may make a network call; if ctx is already cancelled we should
 		// surface that without spending a syscall on it.
+		//
+		// When ctx is cancelled, return ctx.Err() unconditionally — even when
+		// a prior iteration left lastErr set. The post-fn ctx check below
+		// (after the call) returns ctx.Err() too, and these two paths must
+		// agree: ctx cancellation is operator intent ("stop now") that
+		// trumps a previous transient. Returning lastErr here lets the
+		// transient mask the cancellation, which races the
+		// ContextCancellationAbortsLoop test when the ctx-vs-timer select
+		// goes to the timer first.
 		if err := ctx.Err(); err != nil {
-			if lastErr != nil {
-				return zero, lastErr
-			}
 			return zero, err
 		}
 		// Check overall budget before each attempt (after the first).

--- a/src/provider/core/retry_test.go
+++ b/src/provider/core/retry_test.go
@@ -95,12 +95,18 @@ func TestRetryableQuery_ContextCancellationAbortsLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var calls int32
 	go func() {
-		// Cancel after first attempt.
+		// Cancel mid-sleep on the first iteration.
 		time.Sleep(20 * time.Millisecond)
 		cancel()
 	}()
 	policy := zeroJitterPolicy(10)
-	policy.InitialBackoff = 50 * time.Millisecond // long enough for cancel to land mid-sleep
+	// InitialBackoff alone isn't enough — zeroJitterPolicy sets MaxBackoff
+	// to 10ms which would silently clamp the sleep below the cancel time
+	// (20ms). Override BOTH so the cancel reliably lands during the first
+	// iteration's backoff sleep, and the select-on-ctx-Done path is
+	// deterministically exercised.
+	policy.InitialBackoff = 200 * time.Millisecond
+	policy.MaxBackoff = 200 * time.Millisecond
 	_, err := RetryableQuery(ctx, policy, func(_ context.Context) (string, error) {
 		atomic.AddInt32(&calls, 1)
 		return "", &TransientError{Kind: TransientRateLimit}
@@ -110,6 +116,40 @@ func TestRetryableQuery_ContextCancellationAbortsLoop(t *testing.T) {
 	}
 	if calls < 1 {
 		t.Errorf("expected at least 1 call, got %d", calls)
+	}
+}
+
+// TestRetryableQuery_CtxCancelBetweenIterationsReturnsCtxErr targets the
+// race window where the timer wins the select (sleep finishes first) but
+// ctx is cancelled before the next iteration's check. Pre-fix, the
+// top-of-loop check returned lastErr (the previous transient) instead of
+// ctx.Err(), masking the cancellation.
+//
+// Synthesized deterministically: pre-cancel an already-set-up ctx, then
+// run with a transient-returning fn that sets lastErr on the first call,
+// and assert the final error wraps context.Canceled rather than the
+// transient.
+func TestRetryableQuery_CtxCancelBetweenIterationsReturnsCtxErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int32
+	policy := zeroJitterPolicy(3)
+	// Tiny backoff so the timer wins the select reliably, leaving the
+	// top-of-loop ctx check as the only place ctx.Err() can be observed.
+	policy.InitialBackoff = 1 * time.Millisecond
+	policy.MaxBackoff = 1 * time.Millisecond
+
+	_, err := RetryableQuery(ctx, policy, func(_ context.Context) (string, error) {
+		c := atomic.AddInt32(&calls, 1)
+		// Cancel after the first transient is observed but before the
+		// second call would run. With 1ms backoff the timer fires fast,
+		// so the cancellation must land between iterations.
+		if c == 1 {
+			cancel()
+		}
+		return "", &TransientError{Kind: TransientRateLimit}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v (lastErr should NOT mask ctx cancellation)", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the `TestRetryableQuery_ContextCancellationAbortsLoop` flake observed on PR #163's CI run (5/5 local passes; one CI fail with `"expected context.Canceled, got transient error (rate_limit)"`). Two real issues found:

## 1. Internal inconsistency in `RetryableQuery`

The retry loop has TWO ctx-cancellation checks that disagreed:

- **Line 75-80 (top of iteration)** — when `ctx.Err() != nil` AND `lastErr` was set, returned `lastErr` (the previous transient).
- **Line 99-102 (after fn call)** — explicitly returns `ctx.Err()`, with the comment *"Context cancelled: surface that, not the inner error."*

The race window — when the sleep timer wins the `select`-on-`ctx.Done()`, then ctx is cancelled before the next iteration's top-of-loop check — produced the transient (via the inconsistent path) instead of `context.Canceled` (the documented intent).

**Fix**: top-of-loop check now returns `ctx.Err()` unconditionally. ctx cancellation is operator intent ("stop now") and trumps a previous transient. Both ctx checks now agree.

## 2. Test policy silently clamped below the cancel time

The test set `policy.InitialBackoff = 50ms` with the comment `"long enough for cancel to land mid-sleep"` (cancel fires at 20ms). But `zeroJitterPolicy` sets `MaxBackoff = 10ms`, which clamps every sleep below the cancel time. So cancellation could land BETWEEN iterations rather than during one — exactly the race the bug exposed.

**Fix**: test now overrides BOTH `InitialBackoff` AND `MaxBackoff` to 200ms so the cancel reliably lands during the first iteration's backoff sleep, and the `select`-on-`ctx.Done()` path is deterministically exercised.

## Regression test added

`TestRetryableQuery_CtxCancelBetweenIterationsReturnsCtxErr` targets the specific race window the bug fix closes — synthesized deterministically by cancelling inside `fn()` so the next iteration's ctx check is the only place ctx cancellation can be observed. With 1ms backoff the timer wins reliably; the test asserts the final error wraps `context.Canceled` rather than the transient. Pre-fix this would have failed by returning the `lastErr` transient.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./src/provider/core/ -count=10` — 100% pass
- [x] `go test ./src/provider/core/ -count=20 -race` — 100% pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>