### PR TITLE
fix(ci): align Go version pins to 1.25 (matches go.mod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@v2.23.0
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Cache Go modules
         uses: actions/cache@v5

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Check for OWASP updates
         id: owasp_check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for LLMrecon
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make ca-certificates tzdata


### PR DESCRIPTION
## Summary

The v0.9.0 release workflow's Docker push step failed with:

> `go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`

`go.mod` has required Go 1.25 since at least v0.8.x, but six places across the repo still pinned 1.24:

| File | Pin |
|---|---|
| `.github/workflows/ci.yml` | `go-version: '1.24'` |
| `.github/workflows/go-security.yml` | (2 occurrences) |
| `.github/workflows/release.yml` | `go-version: '1.24'` |
| `.github/workflows/template-update.yml` | `go-version: '1.24'` |
| `Dockerfile` | `FROM golang:1.24-alpine` |

## Why CI mostly worked anyway

GitHub Actions defaults `GOTOOLCHAIN=auto`, which auto-fetches the toolchain `go.mod` requires. The Docker Alpine container has `GOTOOLCHAIN=local`, which defeats the auto-fetch and surfaces the version mismatch as a hard error.

## Fix

Bump all six pins to 1.25 to match `go.mod`. Eliminates the GOTOOLCHAIN-dependent serendipity and ensures consistent behavior across CI / Docker / local dev.

## Recovery

After this lands, the failed `Build and Push Docker Image` job in the v0.9.0 release workflow run can be re-run via `gh run rerun 25257277160 --failed` to publish the Docker image. The release tag, binaries, and GitHub release page are already live — only the Docker artifact is missing.

## Test plan

- [x] All 6 pins updated and verified via `grep -rn "1.24" .github/workflows/ Dockerfile`
- [ ] CI re-run on this PR validates the bump (existing tests will fail to import or run if 1.25 has a backwards-incompatible change — none expected)
- [ ] After merge: `gh run rerun 25257277160 --failed` republishes Docker for v0.9.0

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>