### PR TITLE
docs(plans): backfill v0.9.0 + brainstorm + project-health plans

### DIFF
--- a/docs/brainstorms/2026-04-28-v0.9.0-new-attacks-brainstorm.md
+++ b/docs/brainstorms/2026-04-28-v0.9.0-new-attacks-brainstorm.md
@@ -1,0 +1,79 @@
+---
+date: 2026-04-28
+topic: v0.9.0-new-attacks
+---
+
+# v0.9.0 — New LLM Attack Modules (post-v0.8.0 research)
+
+## What We're Building
+
+A v0.9.0 release that adds **6 Go attack modules and 5 templates** covering recent (Q4 2025 – Q2 2026) LLM/agentic-AI attack research that is not yet present in the tool. The release fills three OWASP Agentic Top-10 2026 gaps (notably ASI06 Memory & Context Poisoning), introduces the tool's first black-box fuzzing engine for jailbreak auto-discovery, and extends multimodal and reasoning-model coverage.
+
+The hybrid split is intentional: **templates** carry static attacks where the payload itself is the contribution (H-CoT prepend, persona seeds, EchoLeak chain, reverse-CAPTCHA, system-prompt surface). **Go modules** carry attacks that need state, feedback loops, or multi-step orchestration (memory poisoning across sessions, JBFuzz mutation+feedback, genetic persona evolution, multimodal payload assembly).
+
+## Why This Approach
+
+Three approaches were considered:
+- **A. Lean & High-Confidence (chosen)** — Trims only items with real implementation barriers in a black-box LLM tester (server-side RCEs, white-box gradient generation, multi-objective NSGA-II).
+- **B. Comprehensive** — Adds EvoJail (NSGA-II), UltraBreak corpus, MCP STDIO detection. Higher delivery risk on the research-grade items.
+- **C. Engines-First** — Auto-discovery only. Drops three of the four research families the user wanted covered.
+
+Approach A honors "all of these we can actually successfully implement" by skipping items that belong in a different tool category (server CVE scanning) or require model weights we don't have. Every chosen module follows the existing v0.8.0 self-registration pattern in `src/attacks/` and uses `attacks.DefaultRegistry`.
+
+## Key Decisions
+
+- **ASI06 Memory & Context Poisoning becomes a first-class package** — `src/attacks/memory/` with three modules (MINJA, MemoryGraft, InjecMEM) targeting vector-DB-backed long-term agent memory. Rationale: this is the single largest documented gap in our OWASP Agentic mapping, and all three techniques are pure black-box (query-only access).
+- **JBFuzz introduces a new attack paradigm: black-box fuzzing engine.** Rationale: 99% ASR in ~60s in published results; fits cleanly into `src/attacks/adaptive/` next to existing CAMEL/diffusion/salt-resistance modules; gives the tool an adaptive auto-discovery capability it currently lacks.
+- **H-CoT becomes a reasoning-model module, distinct from existing `cot_exploitation`.** Rationale: existing module exploits trace exposure (data leakage); H-CoT modifies the displayed reasoning and reinjects it to hijack the safety pathway — different attack surface, different target behavior.
+- **Genetic persona modulation = engine module + seed template.** Rationale: 50–70% refusal reduction depends on evolution; pure templates can't deliver fitness-based mutation. Seed templates ship a starter library that the engine evolves.
+- **Multimodal additions: SIVA + VSH only; UltraBreak deferred.** Rationale: SIVA (split image) and VSH (narrative+image hypnosis) are constructible from harmful-prompt corpora using image manipulation primitives. UltraBreak requires gradient optimization on a surrogate VLM — out of scope for runtime black-box; defer to a corpus-shipping mechanism in v0.10.0.
+- **EchoLeak ships as a template chain, not a Go module.** Rationale: the technique is a payload chain (XPIA-evasion text + reference-style markdown link smuggle + auto-fetched-image trigger). Templating it makes it reusable across any RAG-aware target without coupling to M365 specifics.
+- **Skip vLLM RCE (CVE-2026-22778) and MCP STDIO RCE.** Rationale: these are server-side memory-corruption / config-injection vulns. They belong in a CVE/server scanner, not a black-box LLM behavioral tester. Adding them would blur tool scope and introduce code with weaponizable RCE payloads.
+- **Single v0.9.0 release.** Rationale: easier to validate the OWASP Agentic mapping refresh and CHANGELOG once; users get a coherent upgrade story.
+
+### Module Inventory (planned)
+
+| Path | Type | Source |
+|---|---|---|
+| `src/attacks/memory/minja.go` | Go module | arXiv 2503.03704 |
+| `src/attacks/memory/memorygraft.go` | Go module | arXiv 2512.16962 |
+| `src/attacks/memory/injecmem.go` | Go module | OpenReview QVX6hcJ2um |
+| `src/attacks/reasoning/h_cot.go` | Go module | arXiv 2502.12893 |
+| `src/attacks/adaptive/jbfuzz.go` | Go module | arXiv 2503.08990 |
+| `src/attacks/adaptive/persona_evolve.go` | Go module | arXiv 2507.22171 |
+| `src/attacks/multimodal/siva.go` | Go module | arXiv 2602.08136 |
+| `src/attacks/multimodal/vsh.go` | Go module | ScienceDirect S0031320325010520 |
+| `templates/cot_hijack_prepend.json` | Template | arXiv 2510.26418 |
+| `templates/genetic_persona_seeds.json` | Template | arXiv 2507.22171 |
+| `templates/echoleak_chain.json` | Template | arXiv 2509.10540 / CVE-2025-32711 |
+| `templates/reverse_captcha.json` | Template | arXiv 2603.00164 |
+| `templates/system_prompt_surface.json` | Template | arXiv 2603.25056 |
+
+## Open Questions
+
+- **OWASP Agentic mapping update** — `src/compliance/owasp_agentic.go` and `templates/owasp_agentic_2026.yaml` need new entries for memory-poisoning techniques under ASI06 and persona/H-CoT under ASI01 Goal Hijack. Confirm at planning time whether to extend `TechniqueToAgenticCategories()` or rebuild.
+- **Safety gates** — Confirm which new modules need `allow_experimental=true` (likely: JBFuzz at high mutation depth, persona_evolve, MemoryGraft due to persistence implications). H-CoT probably does not.
+- **Reasoning-trace provider support** — H-CoT requires the provider adapter to surface the model's displayed reasoning trace. Verify which existing adapters in `src/provider/` already expose this for o1/o3/R1/Gemini-Thinking; gap-fill if missing.
+- **Memory backend abstraction** — Memory modules need a target memory store. Decide: do we test against a configurable real backend (Pinecone/Weaviate/Chroma fixture), or against an agent endpoint that internally manages memory? Probably the latter for black-box fidelity.
+- **JBFuzz corpus sourcing** — JBFuzz needs seed jailbreak templates to mutate. Reuse existing templates (`flipattack.json`, `drattack.json`, etc.) as the seed corpus, or ship a dedicated `templates/jbfuzz_seeds/` directory?
+- **Multimodal payload assets** — SIVA/VSH need image fragments / scenario images. Decide whether to generate synthetically at runtime, ship a stock corpus, or accept user-provided images.
+
+## Next Steps
+
+→ `/workflows:plan` for implementation details.
+
+## Research Sources
+
+- [JBFuzz: Jailbreaking LLMs Efficiently and Effectively Using Fuzzing (arXiv 2503.08990)](https://arxiv.org/abs/2503.08990)
+- [H-CoT: Hijacking the Chain-of-Thought Safety Reasoning Mechanism (arXiv 2502.12893)](https://arxiv.org/abs/2502.12893)
+- [Chain-of-Thought Hijacking (arXiv 2510.26418)](https://arxiv.org/html/2510.26418v1)
+- [A Practical Memory Injection Attack against LLM Agents — MINJA (arXiv 2503.03704)](https://arxiv.org/html/2503.03704v1)
+- [MemoryGraft: Persistent Compromise of LLM Agents via Poisoned Experience Retrieval (arXiv 2512.16962)](https://arxiv.org/abs/2512.16962)
+- [InjecMEM: Memory Injection Attack on LLM Agent Memory Systems (OpenReview)](https://openreview.net/forum?id=QVX6hcJ2um)
+- [Enhancing Jailbreak Attacks on LLMs via Persona Prompts (arXiv 2507.22171)](https://arxiv.org/abs/2507.22171)
+- [EchoLeak: First Real-World Zero-Click Prompt Injection Exploit (arXiv 2509.10540 / CVE-2025-32711)](https://arxiv.org/abs/2509.10540)
+- [Robustness of Vision Language Models Against Split-Image Harmful Input Attacks — SIVA (arXiv 2602.08136)](https://arxiv.org/abs/2602.08136)
+- [Jailbreak attack with multimodal virtual scenario hypnosis — VSH (ScienceDirect)](https://www.sciencedirect.com/science/article/abs/pii/S0031320325010520)
+- [Reverse CAPTCHA: Evaluating LLM Susceptibility to Invisible Unicode Instruction Injection (arXiv 2603.00164)](https://arxiv.org/html/2603.00164v1)
+- [The System Prompt Is the Attack Surface (arXiv 2603.25056)](https://arxiv.org/abs/2603.25056)
+- [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)

--- a/docs/plans/2026-02-12-refactor-project-health-improvement-plan.md
+++ b/docs/plans/2026-02-12-refactor-project-health-improvement-plan.md
@@ -1,0 +1,252 @@
+---
+title: "refactor: LLMrecon Project Health Improvement Plan"
+type: refactor
+date: 2026-02-12
+---
+
+# LLMrecon Project Health Improvement Plan
+
+## Overview
+
+Comprehensive audit of the LLMrecon project revealing **26 actionable issues** across testing, security, CI/CD, documentation, and code quality. The project has strong architectural foundations and impressive attack module breadth, but critical gaps in testing infrastructure, version consistency, and security hygiene undermine reliability. This plan prioritizes fixes by impact and risk.
+
+## Current Scorecard
+
+| Area | Grade | Key Issue |
+|------|-------|-----------|
+| **Go Build** | B | Compiles, but 3 packages fail `go vet` |
+| **Test Coverage** | F | `*_test.go` in .gitignore; ~1.2% coverage |
+| **Python Health** | C | 1 broken file, missing deps, no pytest |
+| **CI/CD** | C- | No `go test` in CI, disabled security checks |
+| **Documentation** | D+ | Broken links, version chaos, wrong emails |
+| **Security Hygiene** | D | Hardcoded admin password, unsafe deserialization, race conditions |
+| **Dependencies** | B+ | Mostly current; gym deprecated, sqlite3/CGO conflict |
+| **Architecture** | A- | Well-organized 186 packages, clean separation |
+
+---
+
+## Phase 1: Critical Fixes (Blocking)
+
+### 1.1 Remove `*_test.go` from .gitignore
+- **File:** `.gitignore:32`
+- **Problem:** ALL Go test files are excluded from version control. This is the single most impactful bug.
+- **Fix:** Remove the `*_test.go` line, commit existing test files
+- **Impact:** Enables test tracking for the entire Go codebase
+
+### 1.2 Fix Go vet format-string errors
+- **Files:** `src/bundle/import.go:906`, `src/repository/cache_manager.go:130,194,266,334`, `src/ui/` (73+ instances)
+- **Problem:** Non-constant format strings in `fmt.Errorf()` / `fmt.Sprintf()` cause build failures under `go vet`
+- **Fix:** Wrap dynamic strings with `"%s"` format specifier
+- **Example:**
+  ```go
+  // Before (broken)
+  fmt.Errorf(errMsg)
+  // After (fixed)
+  fmt.Errorf("%s", errMsg)
+  ```
+
+### 1.3 Fix RWMutex pass-by-value race conditions
+- **Files:** `src/security/access/api/middleware.go` (8 instances), `src/security/access/api/server.go` (5 instances), `src/automated/chain/exploit_chain_builder.go:1239`
+- **Problem:** `sync.RWMutex` copied by value instead of passed by pointer, causing race conditions in the security subsystem
+- **Fix:** Change struct fields and constructors to use pointer types
+
+### 1.4 Fix hardcoded admin password
+- **File:** `src/security/access/manager.go:629`
+- **Problem:** Plaintext `"admin"` as PasswordHash in AccessControlManager initialization
+- **Fix:** Use bcrypt or argon2id hashing, load from environment or config
+
+### 1.5 Add `go test` to CI
+- **File:** `.github/workflows/ci.yml`
+- **Problem:** CI runs `go vet` and `gofmt` but never runs `go test`
+- **Fix:** Add `go test ./...` step to CI workflow
+
+### 1.6 Pin Trivy action versions
+- **Files:** `.github/workflows/ci.yml:97`, `.github/workflows/release.yml:245`
+- **Problem:** `aquasecurity/trivy-action@master` is a supply chain attack vector
+- **Fix:** Pin to specific stable tag (e.g., `@v0.30.0`)
+
+---
+
+## Phase 2: High Priority (Correctness & Safety)
+
+### 2.1 Unify version references
+- **Problem:** Version claimed differently everywhere:
+
+| Location | Version |
+|----------|---------|
+| README.md badge | v0.7.1 |
+| RELEASE.md | v0.8.0 |
+| Makefile VERSION | 0.1.0 |
+| SECURITY.md | 1.0.x |
+| .github/SECURITY.md | 0.7.x |
+
+- **Fix:** Create single `VERSION` file at root, derive all others. Update README badge, Makefile, both SECURITY.md files.
+
+### 2.2 Fix Dockerfile Go version mismatch
+- **File:** `Dockerfile`
+- **Problem:** Uses `golang:1.23-alpine` but `go.mod` requires Go 1.24.0
+- **Fix:** Update to `golang:1.24-alpine`
+
+### 2.3 Resolve CGO_ENABLED=0 / sqlite3 conflict
+- **Problem:** `github.com/mattn/go-sqlite3` requires CGO, but Dockerfile and release workflow use `CGO_ENABLED=0`
+- **Options:**
+  - (a) Replace `go-sqlite3` with pure-Go `modernc.org/sqlite` (recommended)
+  - (b) Enable CGO in Docker/release builds
+
+### 2.4 Fix broken documentation references
+- **Missing files referenced in README/CLAUDE.md:**
+  - `SECURITY_UPDATE_v0.7.1.md` (linked from README:362, deleted in cleanup)
+  - `requirements.txt` at root (README:98 says `pip install -r requirements.txt`)
+  - `verify_2025_features.py` (README:202, deleted in cleanup)
+  - `demo.sh` and `harness_config.json` (CLAUDE.md references, deleted in cleanup)
+- **Fix:** Update README and CLAUDE.md to remove dead links, point to correct paths
+
+### 2.5 Standardize contact information
+- **Problem:** Three different security emails and doc URLs:
+  - `security@LLMrecon.org` / `security@llmrecon.io` / `security@llmrecon.ai`
+  - `docs.llmrecon.io` / `docs.llmrecon.ai` / `llmrecon.com`
+- **Fix:** Pick one domain (llmrecon.com) and standardize everywhere
+
+### 2.6 Fix Python llmrecon_indirect.py syntax error
+- **File:** `llmrecon_indirect.py:414-418`
+- **Problem:** Invalid f-string syntax with ternary operators missing parentheses
+- **Fix:** Wrap ternary expressions in parentheses inside f-strings
+
+### 2.7 Enable CodeQL SARIF uploads
+- **File:** `.github/workflows/codeql-analysis.yml`
+- **Problem:** All 3 CodeQL jobs have `upload: false` so findings never reach GitHub Security tab
+- **Fix:** Remove `upload: false` lines
+
+### 2.8 Remove gosec -nosec and -no-fail flags
+- **File:** `.github/workflows/go-security.yml:33`
+- **Problem:** `-nosec` disables inline overrides, `-no-fail` hides all findings
+- **Fix:** Remove both flags, triage existing findings properly
+
+### 2.9 Update OWASP template directory names
+- **Problem:** Template directories use 2023 naming (`llm02-insecure-output`, `llm10-model-theft`) but project claims OWASP 2025 compliance
+- **Fix:** Rename to match 2025 category names. Add missing templates for LLM05 and LLM08.
+
+---
+
+## Phase 3: Medium Priority (Quality & Maintenance)
+
+### 3.1 Clean up .disabled files
+- **Problem:** 21 `.disabled` files in `src/` (e.g., `src/cmd/access_control.go.disabled`)
+- **Fix:** Use Go build tags for optional features, or delete if truly unused
+
+### 3.2 Remove duplicate version/ package
+- **Problem:** `src/version/consolidated/` is byte-for-byte duplicate of `src/version/` (~1,300 lines)
+- **Fix:** Delete `consolidated/` directory, update any imports
+
+### 3.3 Remove dead modules/ directory
+- **Problem:** `modules/` at root has 3 small Go files from earlier incarnation of `src/`
+- **Fix:** Delete `modules/` directory
+
+### 3.4 Add go.work to .gitignore
+- **Problem:** `go.work` and `go.work.sum` committed — these are local dev files
+- **Fix:** Add to .gitignore, remove from tracking
+
+### 3.5 Create pytest infrastructure
+- **Problem:** Python tests are standalone scripts, not automated test suites
+- **Fix:** Add `pytest.ini` or `pyproject.toml`, `conftest.py`, convert existing tests
+
+### 3.6 Replace unsafe deserialization in ML code
+- **Files:** `ml/transfer/cross_model_transfer.py:804`, `ml/storage/model_storage.py:228`
+- **Problem:** Unsafe deserialization allows arbitrary code execution
+- **Fix:** Replace with `torch.load(weights_only=True)` or JSON/safetensors
+
+### 3.7 Migrate gym to gymnasium
+- **File:** `ml/requirements.txt`
+- **Problem:** OpenAI Gym deprecated in 2022, replaced by Gymnasium
+- **Fix:** Change `gym>=0.26.0` to `gymnasium>=0.29.0`, update imports
+
+### 3.8 Create CODEOWNERS file
+- **Fix:** Add `.github/CODEOWNERS` with ownership matrix
+
+### 3.9 Replace fake code review workflow
+- **File:** `.github/workflows/claude-code-review.yml`
+- **Problem:** Always posts "All checks passed" regardless of code quality
+- **Fix:** Either remove or replace with meaningful automated checks
+
+### 3.10 Create root requirements.txt
+- **Problem:** README references `pip install -r requirements.txt` but file doesn't exist at root
+- **Fix:** Create root file or update README to point to correct locations
+
+---
+
+## Phase 4: Nice to Have (Polish)
+
+### 4.1 Add missing CI workflows
+- Lint workflow (golangci-lint, flake8, black, mypy)
+- Integration test workflow (separate from unit tests)
+- Docker image security scan
+- Dependabot auto-merge for patch updates
+
+### 4.2 Enhance release workflow
+- SBOM generation (syft or in-toto)
+- Artifact signing (cosign)
+- Provenance attestation (SLSA framework)
+- Changelog verification
+
+### 4.3 Add Dependabot Docker scanning
+```yaml
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+```
+
+### 4.4 Address code smells
+- 168 ignored errors (`_ = ...`) across Go codebase
+- 28 `panic()` calls in `src/` — replace with error returns
+- 78 TODO/FIXME comments — convert to GitHub issues
+
+### 4.5 Pin Python dependencies
+- **Problem:** `ml/requirements.txt` uses `>=` with no upper bounds
+- **Fix:** Pin exact versions or use compatible release (`~=`) specifier
+
+---
+
+## What Works Well (Keep)
+
+- **Architecture:** Clean layered design (CLI > API > Business Logic > Repository)
+- **Attack breadth:** 45+ modules covering FlipAttack, DrAttack, PAP, MCP, RAG, multi-agent
+- **OWASP Agentic 2026:** Forward-looking compliance mapping
+- **Go build succeeds:** 241K lines across 186 packages compile cleanly
+- **Landing page:** Professional 3-theme site on llmrecon.com
+- **Security scanning infra:** Gosec, Trivy, CodeQL, govulncheck, Dependabot all configured
+- **Release workflow:** Cross-platform builds with checksums, Docker multi-arch
+- **Python ML components:** Well-designed bandit optimizer, data pipeline, DQN agent
+- **Template system:** YAML/JSON attack templates with variations and metadata
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (Week 1): Critical fixes — unblock testing, fix security, fix CI
+Phase 2 (Week 2): High priority — version unification, docs, Python fixes
+Phase 3 (Week 3-4): Medium — cleanup, pytest, dependency updates
+Phase 4 (Ongoing): Polish — enhanced CI, release hardening, code smells
+```
+
+## Acceptance Criteria
+
+- [x] `go test ./...` runs in CI and passes
+- [x] `go vet ./...` passes with zero errors
+- [x] All version references agree on current version
+- [x] No broken links in README, RELEASE.md, or CLAUDE.md
+- [x] CodeQL findings upload to GitHub Security tab
+- [x] All GitHub Actions pinned to specific versions (no @master/@beta)
+- [x] Python `llmrecon_indirect.py` imports without error
+- [x] No hardcoded credentials in codebase
+- [x] Single contact email domain used everywhere
+
+## References
+
+- PR #82: Repo cleanup (130+ files removed)
+- PR #83: Year references + CodeQL v4 upgrade
+- PR #84: Pages workflow fix
+- OWASP LLM Top 10 2025: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+- OWASP Agentic Top 10 2026: https://owasp.org/www-project-agentic-ai-threats/
+- Go vet documentation: https://pkg.go.dev/cmd/vet

--- a/docs/plans/2026-04-28-feat-v0-9-0-attack-additions-plan.md
+++ b/docs/plans/2026-04-28-feat-v0-9-0-attack-additions-plan.md
@@ -1,0 +1,508 @@
+---
+title: "feat: v0.9.0 — new LLM attack modules (memory poisoning, JBFuzz, H-CoT, multimodal, persona)"
+type: feat
+date: 2026-04-28
+brainstorm: docs/brainstorms/2026-04-28-v0.9.0-new-attacks-brainstorm.md
+deepened: 2026-04-28
+trimmed: 2026-04-28
+---
+
+# v0.9.0 — New LLM Attack Modules
+
+## Plan Status
+
+Initial plan → deepened by 10 reviewers → trimmed by DHH/Kieran/Simplicity convergence. The deepening surfaced real correctness gaps (codegen for OWASP map, parameterized templates, idempotent migration, ISP-split memory interfaces) that were retained. The trimming cut accreted machinery that had no v0.9.0 consumer (agent-native CLI, `Purger`, 5 of 8 audit columns, tiered budget profiles, embedding fitness as default).
+
+**Effort:** ~8 days single-developer.
+
+## Overview
+
+v0.9.0 adds **6 Go attack modules and 5 templates** covering recent (Q4 2025 – Q2 2026) LLM and agentic-AI attack research not yet present in the tool. The release fills the OWASP Agentic Top-10 2026 **ASI06 Memory & Context Poisoning** gap, introduces the tool's first **black-box fuzzing engine** for jailbreak auto-discovery, and extends multimodal and reasoning-model coverage.
+
+The hybrid implementation split is deliberate: **templates** carry static attacks where the payload is the contribution; **Go modules** carry attacks that need state, multi-turn orchestration, optional provider interfaces, or feedback loops.
+
+## Problem Statement
+
+Since v0.8.0 (~45 attack modules across 2024–2026 research) shipped, several high-impact attack families have been published:
+
+- **Memory poisoning** (MINJA, MemoryGraft, InjecMEM) — corrupts agent long-term memory across sessions; ASI06 is the largest unfilled mapping in our compliance YAML.
+- **JBFuzz** (arXiv 2503.08990, Mar 2026) — black-box fuzzing engine reporting 99% ASR in ~60s. The tool currently has no mutation+feedback fuzzer.
+- **H-CoT / Chain-of-Thought Hijacking** (arXiv 2502.12893, 2510.26418) — drops refusal 98%→2% on o1/o3/R1 via displayed-reasoning hijack. Distinct from existing `cot_exploitation` (trace-exposure data leakage).
+- **Persona modulation** (arXiv 2507.22171) — 50–70% refusal reduction; synergistic with other attacks.
+- **EchoLeak** (arXiv 2509.10540 / CVE-2025-32711) — first real-world zero-click prompt-injection chain in production.
+- **SIVA, VSH** (arXiv 2602.08136, ScienceDirect S0031320325010520) — split-image and virtual-scenario-hypnosis multimodal jailbreaks.
+- **Reverse CAPTCHA** (arXiv 2603.00164) and **System Prompt as Attack Surface** (arXiv 2603.25056) — invisible-Unicode and configuration-driven surface tests.
+
+## Proposed Solution
+
+Single coordinated v0.9.0 release that:
+
+1. Lands minimal **infrastructure**: `AttackOutcome` 3-state enum, retry helper with 2-category typed errors, codegen for OWASP map, `ReasoningProvider` implementations, new `ImageProvider` / `SessionProvider` / `MemoryProbe` interfaces, optional `Cleaner` interface.
+2. Adds **6 Go attack modules** across `src/attacks/{memory,reasoning,adaptive,multimodal}/`. Memory poisoning is one parameterized module registering 3 distinct techniques.
+3. Adds **5 templates** matching the existing flat JSON schema, with weaponized text fields parameterized via `{{PLACEHOLDERS}}`.
+4. Updates the **OWASP Agentic 2026** mapping by codegen from the YAML single source of truth.
+5. Extends the **ML data pipeline** schema with 3 columns (`outcome`, `parent_run_id`, `generation`) under idempotent migration.
+
+## Technical Approach
+
+### Outcome Taxonomy
+
+3-state outcome enum (collapsed from initial 6 per consensus). Captures bandit-relevant distinction without proliferating switch-statement variants.
+
+```go
+// In src/attacks/common/types.go (additive, backward-compatible)
+type AttackOutcome string
+const (
+    OutcomeSuccess AttackOutcome = "success"   // attack landed
+    OutcomeRefused AttackOutcome = "refused"   // ran fully, target resisted
+    OutcomeSkipped AttackOutcome = "skipped"   // didn't run to completion (capability missing, gate blocked, budget out, provider error)
+)
+
+type SkipReason string
+const (
+    SkipMissingCapability    SkipReason = "missing_capability"
+    SkipGateBlocked          SkipReason = "gate_blocked"
+    SkipBudgetExceeded       SkipReason = "budget_exceeded"
+    SkipProviderError        SkipReason = "provider_error"
+    SkipPreconditionFailed   SkipReason = "precondition_failed"
+    SkipModelRefusedImage    SkipReason = "model_declined_image_input"
+    SkipReasoningTraceEmpty  SkipReason = "reasoning_trace_empty"
+    SkipSignatureGated       SkipReason = "anthropic_signature_blocks_mutation"
+    SkipNoMutationTarget     SkipReason = "no_safety_step_to_hijack"
+    SkipMemoryNotRetained    SkipReason = "provider_reports_no_memory_retention"
+)
+
+// AttackResult — typed promotion (no Metadata-key drift):
+type AttackResult struct {
+    // … existing fields …
+    Outcome    AttackOutcome `json:"outcome"`
+    SkipReason SkipReason    `json:"skip_reason,omitempty"`
+    SkipDetail string        `json:"skip_detail,omitempty"` // human-readable
+    CleanupHint string       `json:"cleanup_hint,omitempty"` // memory modules; manual operator cleanup until v0.10.0 Purger
+    // Success kept for backward-compat as a *method*, not a field — prevents desync.
+}
+
+// NewAttackResult is the only blessed constructor; lint forbids direct struct literals
+// on AttackResult outside this package.
+func NewAttackResult(technique string, outcome AttackOutcome) *AttackResult { … }
+
+// Success derives from Outcome; not a field. Backward compat for v0.8.0 consumers.
+func (r *AttackResult) Success() bool { return r.Outcome == OutcomeSuccess }
+```
+
+`population_trajectory` is the only new piece kept in `Metadata` (engine-vs-single-shot abstraction split deferred to v0.10.0). `generation` is *removed* from `AttackResult` and *removed* from the DB schema for v0.9.0 — it lives inside `population_trajectory_summary` JSON, eliminating the typed-DB / untyped-Go mid-state Kieran flagged.
+
+**Property test (`common/types_test.go`):** invariants — (a) `r.Success() ⟺ r.Outcome == OutcomeSuccess`; (b) `Outcome == OutcomeSkipped ⟹ SkipReason != ""`; (c) `CleanupHint != "" ⟹ technique in {memory poisoning techniques}`.
+
+### Module Inventory
+
+| Path | Type | Source | OWASP Agentic | OWASP LLM | Safety Gate |
+|---|---|---|---|---|---|
+| `src/attacks/memory/poisoning.go` (parameterized; 3 techniques) | Go module | arXiv 2503.03704, 2512.16962, OpenReview QVX6hcJ2um | ASI06 (+ASI10 for graft) | LLM01, LLM03 | `i_understand_risks` for all three |
+| `src/attacks/reasoning/h_cot.go` (OpenAI-scoped; Anthropic skips) | Go module | arXiv 2502.12893 | ASI01 | LLM01 | `i_understand_risks` |
+| `src/attacks/adaptive/jbfuzz.go` | Go module | arXiv 2503.08990, 2502.18504 | ASI01 | LLM01 | `allow_experimental` |
+| `src/attacks/adaptive/persona_evolve.go` | Go module | arXiv 2507.22171 | ASI01, ASI09 | LLM01 | `allow_experimental` |
+| `src/attacks/multimodal/siva.go` | Go module | arXiv 2602.08136 | ASI01 | LLM01 | none |
+| `src/attacks/multimodal/vsh.go` | Go module | ScienceDirect | ASI01 | LLM01 | none |
+| `templates/cot_hijack_prepend.json` | Template | arXiv 2510.26418 | ASI01 | LLM01 | n/a |
+| `templates/genetic_persona_seeds.json` | Template (corpus) | arXiv 2507.22171 | ASI01 | LLM01 | n/a |
+| `templates/echoleak_chain.json` (placeholder-parameterized) | Template | arXiv 2509.10540 | ASI04, ASI06 | LLM01, LLM07 | n/a |
+| `templates/reverse_captcha.json` (placeholder-parameterized) | Template | arXiv 2603.00164 | ASI01 | LLM01 | n/a |
+| `templates/system_prompt_surface.json` | Template | arXiv 2603.25056 | ASI03 | LLM01, LLM06 | n/a |
+
+Add `CategoryMemory AttackCategory = "memory"` to `src/attacks/common/types.go` (does not currently exist).
+
+### Provider Interfaces
+
+Per architecture review's ISP recommendation; **`Purger` deferred to v0.10.0** (no provider implements it in v0.9.0). Memory modules emit a manual `CleanupHint` string instead.
+
+```go
+// src/provider/core/capabilities.go (additions)
+
+type ImageProvider interface {
+    common.Provider
+    QueryWithImages(ctx context.Context, prompt string, images []ImagePayload) (*ChatCompletionResponse, error)
+}
+
+type ImagePayload struct {
+    bytes    []byte           // unexported; constructor validates
+    url      string           // unexported; mutually exclusive with bytes
+    mimeType ImageMimeType    // typed enum
+    detail   ImageDetail      // typed enum (advisory; provider may ignore)
+}
+type ImageMimeType string
+const (ImageJPEG ImageMimeType = "image/jpeg"; ImagePNG = "image/png"; ImageGIF = "image/gif"; ImageWebP = "image/webp")
+type ImageDetail string
+const (ImageDetailLow ImageDetail = "low"; ImageDetailHigh = "high"; ImageDetailAuto = "auto")
+func NewImagePayloadBytes(b []byte, mt ImageMimeType, d ImageDetail) (ImagePayload, error)
+func NewImagePayloadURL(url string, d ImageDetail) (ImagePayload, error)
+
+// SessionProvider — for memory-poisoning cross-session verification.
+type SessionProvider interface {
+    common.Provider
+    SessionID() string
+    NewSession(ctx context.Context) (common.Provider, error)
+}
+
+// MemoryProbe — read-only memory introspection. Separate from SessionProvider per ISP.
+type MemoryProbe interface {
+    common.Provider
+    ProbeMemory(ctx context.Context) (retains bool, err error)
+}
+
+// Cleaner — optional method on attack modules that perform persistent state changes.
+// Separate interface, not a default-no-op AttackModule method (Go has no default methods).
+type Cleaner interface {
+    Cleanup(ctx context.Context, ids []string) error
+}
+```
+
+`common.Provider` vs `core.Provider` mismatch: capabilities embed `common.Provider`; existing `core.Provider` becomes a thin alias. Type-assertion in `Execute()` is the discovery path; `Capabilities() []Capability` deferred to v0.10.0 with the agent-native CLI surface.
+
+### Engine Budget
+
+```go
+type EngineBudget struct {
+    MaxQueries          int
+    MaxWallClockSeconds int
+    MaxGenerations      int
+    EarlyStopOnSuccess  bool
+}
+
+// Defaults (no tiered profiles for v0.9.0):
+//   MaxQueries=100, MaxWallClockSeconds=180, MaxGenerations=25, EarlyStopOnSuccess=true
+
+// Hard ceilings — clamped at Execute() entry, log warning when clamped:
+const (
+    HardMaxQueries     = 5000
+    HardMaxWallClock   = 1800   // 30 min
+    HardMaxGenerations = 200
+)
+```
+
+`MaxCostUSD` (existing on `AttackConfig`, line 107) honored via existing `CostExceeded` helper. `BudgetExceededBehavior` cut (one valid value). `MaxJudgeCalls` cut for v0.9.0 default — embedding fitness is opt-in only (refusal-heuristic is default), so judge-call cost is only an issue under explicit opt-in.
+
+### Build Sequence
+
+```
+Phase 1 (foundation) — INTERFACES & SHARED INFRASTRUCTURE
+  ├─ src/attacks/common/types.go              (CategoryMemory, AttackOutcome, SkipReason, EngineBudget, NewAttackResult constructor, Success() method)
+  ├─ src/provider/core/capabilities.go        (ImageProvider, SessionProvider, MemoryProbe, ImagePayload typed enums + constructors)
+  ├─ src/provider/core/retry.go (NEW)         (RetryableQuery + 2-category typed errors)
+  ├─ src/provider/core/errors.go (NEW)        (ErrTransient, ErrPermanent — struct types implementing Is())
+  ├─ src/compliance/gen.go (NEW)              (//go:generate codegen for OWASP map; YAML is source of truth)
+  ├─ src/compliance/owasp_agentic_generated.go (GENERATED — kept out of git via .gitignore; regenerated by go:generate in CI)
+  ├─ Provider implementations (parallel after interfaces commit):
+  │   ├─ src/provider/openai/provider.go      (Responses API for reasoning; image_url for vision)
+  │   └─ src/provider/anthropic/provider.go   (extended-thinking blocks for reasoning [SIGNATURE LIMITATION DOCUMENTED]; image content blocks)
+  └─ testdata/images/                         (4–6 pre-built PNGs, ≤200KB; SubImage inline in siva.go)
+
+Phase 2 (templates — parallel with Phase 1)
+  └─ templates/{cot_hijack_prepend,genetic_persona_seeds,echoleak_chain,reverse_captcha,system_prompt_surface}.json
+      (echoleak_chain & reverse_captcha use {{HARMFUL_INSTRUCTION}}/{{EXFIL_URL}} placeholders; loader rejects unfilled)
+
+Phase 3 (modules — depends on Phase 1)
+  ├─ src/attacks/memory/poisoning.go          (parameterized; 3 init() blocks register minja/memorygraft/injecmem)
+  ├─ src/attacks/reasoning/h_cot.go           (OpenAI Responses-API path; Anthropic emits SkipSignatureGated)
+  └─ src/attacks/multimodal/{siva,vsh}.go     (post-check for image-blind refusal indicators)
+
+Phase 4 (engines)
+  ├─ src/attacks/adaptive/jbfuzz.go           (synonym-primary mutation; UCB1+random restart selection; refusal-heuristic fitness DEFAULT, embedding fitness opt-in)
+  └─ src/attacks/adaptive/persona_evolve.go   (struct-of-traits encoding; 5% elitism; tournament-k=3)
+
+Phase 5 (compliance + ML pipeline)
+  ├─ templates/owasp_agentic_2026.yaml        (technique entries — single source of truth)
+  └─ ml/data/attack_data_pipeline.py          (idempotent migration: outcome + parent_run_id + generation; bandit reward filter on outcome)
+
+Phase 6 (docs)
+  ├─ CHANGELOG.md, CLAUDE.md
+  └─ Integration smoke test (one per family)
+```
+
+**Agent-native CLI surface (`--list-techniques --json`, `ConfigSchema()`, etc.) deferred to v0.9.1 / v0.10.0** when a documented agent consumer exists.
+
+### Implementation Phases
+
+#### Phase 1 — Foundation
+
+**Tasks:**
+- Add `AttackOutcome`, `SkipReason`, `EngineBudget`, `CategoryMemory` to `src/attacks/common/types.go`. Add `NewAttackResult(technique, outcome)` constructor and `Success()` method. Forbid direct `AttackResult` struct literals via lint rule.
+- Add `ImageProvider` (typed-enum `ImageMimeType`/`ImageDetail` + constructors), `SessionProvider`, `MemoryProbe`, `Cleaner` to `src/provider/core/capabilities.go`.
+- `src/provider/core/retry.go`: `RetryableQuery(ctx, fn, RetryPolicy)`. `src/provider/core/errors.go`: 2 struct error types — `TransientError` (rate-limit, gateway, timeout — retry with backoff) and `PermanentError` (auth, content-length, model-mismatch — don't retry). Both implement `Is(target error) bool`. **Caller policy on retry exhaustion**: emit `OutcomeSkipped`+`SkipProviderError`; never `Success=false` silently.
+- `src/compliance/gen.go` with `//go:generate` reads `templates/owasp_agentic_2026.yaml` and emits `owasp_agentic_generated.go`. **Generated file is gitignored** (Kieran review fix); CI runs `go generate ./...` and asserts no diff. The hand-written `owasp_agentic.go` keeps `ASI01..ASI10` constants and types.
+- Implement `ReasoningProvider` on OpenAI adapter against the **Responses API**, not Chat Completions. Set `include=["reasoning.encrypted_content"]`, `reasoning.summary="detailed"`. Surface `output[*].summary[].text`. Gate by model class (skip `OutcomeSkipped`+`SkipMissingCapability` for non-reasoning models, never 400).
+- Implement `ReasoningProvider` on Anthropic adapter. **Document the signature limitation prominently in code comment**: modifying `thinking` text on round-trip is silently discarded; `signature` field detection triggers `SkipSignatureGated` in H-CoT module.
+- Implement `ImageProvider` on both adapters: OpenAI uses `image_url` content parts; Anthropic uses `image` source blocks (base64 or URL).
+- `testdata/images/`: 4–6 procedurally generated text-on-blank-bg images for SIVA splits + benign scenic for VSH; ≤200KB total. No separate `imagetools` package — SIVA uses inline `image.SubImage`.
+- `templates/jbfuzz_seeds/`: 8–12 starter seeds in **psychological-theme templates** ("assumed responsibility", "character roleplay") — not DAN-family.
+
+**Research grounding (succinct):** OpenAI Responses API is the correct surface for reasoning models in 2026 (Chat Completions only exposes reasoning *token counts*). OpenAI never returns raw CoT — only summaries — and `o3` omits even with `summary=detailed` >90% of the time. Anthropic `signature` blocks true trace mutation by API design — H-CoT against Claude reduces to template-prepend (`cot_hijack_prepend.json`).
+
+**Deliverables:** capabilities compile; one OpenAI Responses-API integration round-trip test; one Anthropic thinking-block test; image upload tests both adapters.
+**Success criteria:** `go build ./...` and `go test ./src/provider/...` and `go test ./src/compliance/...` pass.
+**Estimated effort:** 2 days.
+
+#### Phase 2 — Static Templates
+
+**Tasks:** create the 5 template files using the **flat JSON schema** verified in `flipattack.json` / `drattack.json` (`{id, name, category, severity, description, prompt, indicators[], variations[{prompt, indicators}], metadata{}}`). `severity ∈ {critical, high, medium, low}`. Do **not** use `format.Template`.
+
+**Critical (security): parameterize weaponized payload text.**
+- `echoleak_chain.json` and `reverse_captcha.json` ship structural scaffolds with `{{HARMFUL_INSTRUCTION}}` / `{{EXFIL_URL}}` placeholders, **not literal harmful instructions**.
+- Loader gains a placeholder-rejection step: if loaded prompt contains unsubstituted `{{...}}` at run time, return error.
+- Operators supply substitutions via `--instruction-file` / `--exfil-url` CLI flags or `AttackConfig.Metadata["instruction"]`.
+
+Per-template content (succinct):
+- `cot_hijack_prepend.json` — harmful query preceded by benign reasoning chain. 4–6 reasoning prefix variations. Operator-supplied harmful instruction.
+- `genetic_persona_seeds.json` — 12+ seed personas using **struct-of-traits encoding** (`{role, expertise, tone, motivation, constraints, backstory, traits[], style{}, fitness_seed}`).
+- `echoleak_chain.json` — three-stage scaffold (XPIA-evasion email + ref-markdown link smuggle + sensitive-context exfil). Variations cover M365, Gmail, generic RAG.
+- `reverse_captcha.json` — invisible Unicode-tag-encoded `{{HARMFUL_INSTRUCTION}}` plus zero-width-binary variant. Per-provider preference noted.
+- `system_prompt_surface.json` — battery of malicious system-prompt configs: role inversion, hierarchy abuse, identity ambiguity. Maps to ASI03.
+
+**Deliverables:** 5 template files; placeholder-rejection smoke test; `flipattack.json` continues to load unchanged.
+**Estimated effort:** 1 day.
+
+#### Phase 3 — Standalone Modules
+
+Per-module scaffolding:
+
+1. Struct + `init()` registering with `attacks.DefaultRegistry`. Pointer-to-struct: `&FooModule{}`. Type names use `*Module` suffix verbatim.
+2. `Name() / Category() / Description() / Techniques()`. `Techniques()` populates both `OWASPLLMCategories` and `OWASPAgenticCategories`.
+3. Safety-gate check at `Execute()` entry (verbatim from `rce_chain.go:68-74`):
+   ```go
+   if config.Metadata["i_understand_risks"] != "true" {
+       return common.NewAttackResult("memorygraft", common.OutcomeSkipped).
+           WithSkip(common.SkipGateBlocked, "memorygraft requires i_understand_risks=true"), nil
+   }
+   ```
+4. Capability discovery via type assertion. **Defensive policy on assertion failure**: log warning, return `OutcomeSkipped`+`SkipMissingCapability`. (Single documented policy across all modules.)
+5. Multi-step orchestration per module.
+6. **Optional `Cleanup(ctx, ids []string) error`** via separate `Cleaner` interface — type-asserted by CLI, not a default-no-op method on `AttackModule`. Memory modules implement; others do not.
+7. `*_test.go` per module using `testutil.MockProvider`. **v0.9.0 establishes per-module test convention.**
+
+**`memory/poisoning.go`** (single state machine, 3 `init()` registrations):
+- Phases: probe → seed → inject (payload form differs by mode: query-bound for minja/injec, episodic-experience for graft) → wait `intervening_turns` → trigger (same-session for injec/minja, fresh `SessionProvider.NewSession` for graft) → verify indicator match.
+- All three modes require `i_understand_risks=true`.
+- **Cleanup**: emits `CleanupHint` string with injected record IDs and operator instructions ("purge IDs <list> via your provider's memory console; v0.9.0 does not auto-purge"). `Cleaner` interface unimplemented for v0.9.0 — manual operator step.
+- Skip outcomes module can emit: `SkipMissingCapability` (no `MemoryProbe`), `SkipMemoryNotRetained` (probe returned `(false, nil)`), `SkipProviderError` (probe returned error), `SkipGateBlocked` (no `i_understand_risks`).
+
+**`reasoning/h_cot.go`** — OpenAI-scoped. Module name reflects v0.9.0 scope; Anthropic is supported but emits `SkipSignatureGated`:
+- (a) Type-assert `ReasoningProvider`. If absent → `SkipMissingCapability`.
+- (b) Send harmful query, capture `*ThinkingTrace`.
+- (c) **Signature check**: if `trace.Signature != ""` (Anthropic) → `SkipSignatureGated`. Mutation is a no-op against Claude 4.x by API design.
+- (d) Empty trace (OpenAI o3 omits >90% of the time per community reports) → `SkipReasoningTraceEmpty`. Max 3 retries before skip.
+- (e) Locate safety-recognition step. If absent → `SkipNoMutationTarget`.
+- (f) Mutate, re-inject as conversation context, observe response.
+- Requires `i_understand_risks=true`.
+
+**`multimodal/siva.go`** (split-image):
+- Capability check `ImageProvider`, type-assert. Skip if missing.
+- Compose harmful prompt as text (operator-supplied via `Metadata["instruction"]`).
+- Load corpus image, split into `siva_fragment_count` pieces using inline `image.SubImage`.
+- Embed adversarial text overlays per piece.
+- Submit via `ImageProvider.QueryWithImages` as multi-image request.
+- **Image-blind post-check**: if response matches `["cannot process images", "I don't see any image", "unable to view"]` → `SkipModelRefusedImage`.
+
+**`multimodal/vsh.go`** (virtual scenario hypnosis):
+- Same capability + post-check as SIVA.
+- Wrap harmful query in narrative scenario; pair with single contextually plausible scene image.
+
+**Deliverables:** 4 Go module files (memory poisoning collapses 3 into 1), 4 test files. Registry shows 6 new techniques.
+**Estimated effort:** 2.5 days.
+
+#### Phase 4 — Evolutionary Engines
+
+**`adaptive/jbfuzz.go`** — black-box mutation/feedback fuzzer:
+- **Mutation operators**: synonym substitution PRIMARY (POS-preserving, 462× faster than LLM mutation per JBFuzz §4.2). Tier 2: `RefusalSuppression` (TurboFuzzLLM static prefix), `Rephrase`. Drop `template/structural/encoding` from initial scope.
+- **Seed selection**: UCB1 with periodic random restart (every N iters, sample uniformly). MCTS-Explore deferred to v0.10.0.
+- **Fitness — refusal-heuristic DEFAULT**: pattern match against refusal-string indicators ("I can't", "I'm sorry", "I cannot help") with known false-positive caveat documented. **Embedding fitness opt-in** via `--fitness=embedding` (e5-base-v2 + small MLP via ONNX Runtime or local Ollama embeddings endpoint) — not a default; requires explicit operator opt-in to introduce the dep.
+- **Loop**: select top-K → mutate → query target via `core.RetryableQuery` → score → update pool. Bounded by `EngineBudget`. Returns best-of-run as `*AttackResult` with `Outcome=OutcomeSuccess` if best crossed threshold, `OutcomeSkipped`+`SkipBudgetExceeded` if budget hit without success. Population trajectory in `Metadata["population_trajectory"]` (gzipped JSON, summary form).
+- **Hard ceilings clamp** operator config.
+- Requires `allow_experimental=true`.
+
+**`adaptive/persona_evolve.go`** — genetic-algorithm persona modulation:
+- **Crossover rate 0.6**, **mutation rate 0.2** (literature-backed — GAAPO, ReflectivePrompt 2025).
+- **5% elitism** — top-K preserved unchanged across generations.
+- **Population N=30**.
+- **Encoding**: struct-of-traits — slot-based crossover (uniform crossover over slots).
+- **Selection**: tournament k=3.
+- **Fitness**: `f = (1 − refused) × goal_relevance × min(1, len/threshold)`.
+- **Mode-collapse guards**: novelty fitness penalty (cosine sim > 0.9), periodic immigration (every 5 gens, replace bottom 20%).
+- Same budget knobs as JBFuzz.
+- Requires `allow_experimental=true`.
+
+**Deliverables:** 2 engine modules, 2 unit-test files; mock-provider tests verify budget enforcement and hard-ceiling clamping.
+**Estimated effort:** 2 days.
+
+#### Phase 5 — Compliance + ML Pipeline
+
+**Compliance**: `templates/owasp_agentic_2026.yaml` is single source of truth. New `attack_techniques` entries land in YAML. `//go:generate` regenerates `owasp_agentic_generated.go`. Generated file is gitignored; CI runs `go generate ./... && git diff --exit-code` to assert no drift.
+
+**ML pipeline migration** (idempotent, 3 columns only):
+
+```python
+def _migrate_v090(conn, db_path):
+    import shutil, datetime
+    backup = f"{db_path}.bak.{datetime.datetime.utcnow():%Y%m%dT%H%M%SZ}"
+    shutil.copy2(db_path, backup)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(attacks)").fetchall()}
+    pre_count = conn.execute("SELECT COUNT(*) FROM attacks").fetchone()[0]
+    with conn:  # BEGIN IMMEDIATE … COMMIT
+        if "outcome"       not in cols: conn.execute("ALTER TABLE attacks ADD COLUMN outcome TEXT")
+        if "parent_run_id" not in cols: conn.execute("ALTER TABLE attacks ADD COLUMN parent_run_id TEXT")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_attacks_parent_run_id ON attacks(parent_run_id) WHERE parent_run_id IS NOT NULL")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_attacks_outcome      ON attacks(outcome)        WHERE outcome IS NOT NULL")
+    post_cols = {r[1] for r in conn.execute("PRAGMA table_info(attacks)").fetchall()}
+    assert {"outcome", "parent_run_id"} <= post_cols
+    assert conn.execute("SELECT COUNT(*) FROM attacks").fetchone()[0] == pre_count
+    # One-time backfill for legacy rows: outcome='success' if Success=1 else 'refused'
+    conn.execute("UPDATE attacks SET outcome = CASE WHEN success=1 THEN 'success' ELSE 'refused' END WHERE outcome IS NULL")
+```
+
+**Bandit reward filter (CRITICAL)**: aggregate `WHERE outcome IN ('success', 'refused')`. `skipped` outcomes do not enter reward. Document in pipeline docstring.
+
+**Generation column dropped from migration** (lives in `population_trajectory_summary` JSON instead — eliminates Kieran's "worst-configuration mid-state").
+
+**Audit columns dropped** (`target_endpoint_hash`, `payload_hash`, `injected_record_ids`, `cleanup_attempted`, `cleanup_succeeded`, `operator_id`) — no v0.9.0 user-visible feature gates on them. Add when needed.
+
+**Credential redaction**: insert path scrubs `Metadata` keys matching `(?i)(key|token|secret|password|auth)`. Unit test asserts.
+
+**Estimated effort:** 1 day.
+
+#### Phase 6 — Documentation
+
+**Tasks:**
+- **CHANGELOG.md**: `## [0.9.0] - 2026-04-XX` describing additions, the typed `AttackOutcome`, the new optional provider interfaces, the safety-gate flag table, the schema migration, the **Anthropic signature limitation for H-CoT**, integration test cost notes (~$3–$8 per `RUN_INTEGRATION` run).
+- **CLAUDE.md**: extend the attack-package table; document `AttackOutcome` taxonomy.
+- **Integration smoke test**: one end-to-end run per family against `MockLLMServer`. `RUN_INTEGRATION` gating: `t.Skip()` (not failure) when unset.
+
+**Estimated effort:** 0.5 day.
+
+### Total estimated effort
+
+**~8 days single-developer.** Phase split: Phase 1 ≈ 2d; Phases 2/3 ≈ 3.5d; Phase 4 ≈ 2d; Phases 5/6 ≈ 1.5d.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] All new Go modules implement `AttackModule`, self-register via `init()`, and appear in `attacks.DefaultRegistry.List()`.
+- [ ] All 5 new templates parse with the existing JSON loader; placeholder substitution validates at run time.
+- [ ] `ReasoningProvider` is implemented on OpenAI (Responses API) and Anthropic adapters with at least one round-trip integration test each.
+- [ ] `ImageProvider` is implemented on both adapters with at least one image-upload integration test each.
+- [ ] H-CoT against Anthropic returns `OutcomeSkipped`+`SkipSignatureGated`.
+- [ ] H-CoT against OpenAI Responses API performs trace round-trip and returns `OutcomeSuccess` / `OutcomeRefused`.
+- [ ] SIVA/VSH return `OutcomeSkipped`+`SkipModelRefusedImage` when the model declines image input.
+- [ ] Memory modules (all three modes) require `i_understand_risks=true`; rejected runs return `OutcomeSkipped`+`SkipGateBlocked`.
+- [ ] Memory modules emit `CleanupHint` with injected record IDs.
+- [ ] JBFuzz and `persona_evolve` honor all `EngineBudget` knobs and clamp at hard ceilings.
+- [ ] OWASP Agentic mapping single-source-from-YAML via codegen; no hand-edited Go map.
+- [ ] `ml/data/attack_data_pipeline.py` migration runs idempotently; row count preserved; backup created.
+- [ ] Bandit reward aggregation filters by `outcome` (skips do not enter reward).
+- [ ] Credential redaction unit test passes.
+- [ ] Property test passes: `r.Success() ⟺ r.Outcome == OutcomeSuccess`; `OutcomeSkipped ⟹ SkipReason != ""`.
+
+### Non-Functional Requirements
+
+- [ ] All new code passes `go test ./...`; coverage does not regress overall by more than 2pp.
+- [ ] Engine default budget keeps a single run under 100 queries / 180s wall clock.
+- [ ] No new module makes a network call from its unit tests (mock-only).
+- [ ] No persistent file writes from unit tests.
+- [ ] Defensive-only constraint preserved: no module ships a working server-side RCE payload; `echoleak_chain` and `reverse_captcha` ship placeholders only.
+- [ ] Integration test full suite cost documented (~$3–$8 per CI run); `RUN_INTEGRATION` gating with `t.Skip()` when unset; `max_tokens` capped low.
+- [ ] No optional ML dependency (ONNX/Ollama) introduced as a default — opt-in only.
+
+### Quality Gates
+
+- [ ] CHANGELOG.md updated.
+- [ ] CLAUDE.md attack-package table and `AttackOutcome` taxonomy documented.
+- [ ] Codegen drift impossible (`go generate ./... && git diff --exit-code` in CI).
+- [ ] One integration smoke test per family.
+
+## Alternative Approaches Considered
+
+- **Comprehensive (EvoJail + UltraBreak + MCP STDIO)** — Rejected: out-of-scope (server vulns; gradient methods need model weights).
+- **Engines-only** — Rejected: drops three of four research families.
+- **Templates-only** — Rejected: memory/fuzzing/persona/multimodal need state.
+- **Drop `MemoryAware` entirely** — Rejected: persistence claim unverifiable without `NewSession`. ISP split is the right answer.
+- **Cut H-CoT Go module** — Partially adopted: template handles Anthropic case (signature-blocked); Go module retained for OpenAI Responses-API path.
+
+## Risk Analysis & Mitigation
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Anthropic signature blocks H-CoT trace mutation | **Confirmed** | Med | Documented; module emits `SkipSignatureGated`; Anthropic case covered by `cot_hijack_prepend` template prepend. |
+| OpenAI Responses API shape changes mid-cycle | Med | Med | Pin SDK; integration tests behind env var. |
+| `o3` summary omission >90% | High | Low-Med | Document; emit `SkipReasoningTraceEmpty` after 3 retries. |
+| Engine runaway cost | Low | High | Hard ceilings clamp operator config; `MaxCostUSD` honored. |
+| Persona-evolve mode collapse | Med | Med | Tournament-k=3 + novelty penalty + periodic immigration + 5% elitism. |
+| Bandit reward dilution from skips | **Was high; now mitigated** | High | `outcome` column + reward filter excludes skips. |
+| Memory-poisoning leaving target compromised | Med | High | All modes require `i_understand_risks`; `CleanupHint` with operator instructions. **v0.10.0 will add `Purger` + automated cleanup; v0.9.0 documents this gap explicitly in CHANGELOG.** |
+| Repo as weaponized-payload library | **Was med; now mitigated** | High | Templates parameterized with `{{PLACEHOLDERS}}`; loader rejects unfilled. |
+| OWASP YAML/Go drift | **Eliminated** | n/a | Codegen + CI no-diff assertion. |
+| Migration corruption | **Was high; now mitigated** | High | Idempotent check-then-add; backup; partial indexes; row-count verification. |
+| Provider transient errors silently looking like refusal | **Was high; now mitigated** | High | `RetryableQuery` + 2-category typed errors; modules emit `SkipProviderError` on exhausted retries. |
+| Image-blind models reported as robust | **Was med; now mitigated** | Med | SIVA/VSH post-check for image-decline indicators; emit `SkipModelRefusedImage`. |
+
+## Future Considerations (v0.9.1 / v0.10.0)
+
+- **Agent-native CLI surface**: `--list-techniques --json`, `ConfigSchema()` per module, `--explain-result --json`, `--cleanup --run-id` — add when documented agent consumer exists.
+- **`Purger` interface + automated memory cleanup** — when a real backend (Mem0, Letta, Pinecone-with-namespace, Weaviate-with-tenant) lands.
+- **Embedding fitness model as default** for JBFuzz — when ONNX Runtime / Ollama integration is justified by data.
+- **MCTS-Explore selection** for JBFuzz — when UCB1+restart shows local-optima evidence.
+- **EvoJail** multi-objective evolutionary engine; **UltraBreak** corpus + tester interface.
+- **`EngineResult` typed split** (`Best *AttackResult; Trajectory []AttackResult`) replacing the metadata-blob shortcut.
+- **Audit columns** for `target_endpoint_hash`, `payload_hash`, `operator_id` when compliance reporting requires them.
+
+## Open Questions
+
+1. **OpenAI summary omission rate** — at >90% per o3 community reports, max-3 retries before skip is reasonable; revisit if real data shows higher non-empty rate.
+2. **`echoleak_chain.json` exfil URL** — even with placeholders, default behavior is reject-on-load if no `{{EXFIL_URL}}` substitution. Confirmed.
+3. **Reasoning trace storage** — PII risk. Redact-by-default; `--store-reasoning-trace` opt-in flag; trace lives in disk-side trajectory file when opted in.
+
+(Resolved at trim time: image asset licensing → CC0 only; operator identity → not stored in v0.9.0 — defer to compliance reporting work.)
+
+## References
+
+### Internal
+
+- Brainstorm: `docs/brainstorms/2026-04-28-v0.9.0-new-attacks-brainstorm.md`
+- Attack interface: `src/attacks/attack.go:22-66`
+- Shared types: `src/attacks/common/types.go:67-148`
+- Provider capabilities: `src/provider/core/capabilities.go:13-47`
+- Existing safety-gate exemplars: `src/attacks/agentic/persistence/rce_chain.go:68-71`, `agentic/deception/agent_collusion.go:75-77`, `reasoning/autonomous_jailbreak.go:92-95`
+- Mock provider: `src/attacks/testutil/testutil.go:26-115`
+- Existing flat-schema templates: `templates/flipattack.json`, `templates/drattack.json`
+- ML pipeline: `ml/data/attack_data_pipeline.py`
+- Prior plan precedent: `docs/plans/2026-02-11-feat-new-llm-attack-techniques-plan.md`
+
+### Source Papers
+
+- [JBFuzz arXiv 2503.08990](https://arxiv.org/abs/2503.08990)
+- [TurboFuzzLLM arXiv 2502.18504](https://arxiv.org/html/2502.18504)
+- [GPTFuzzer arXiv 2309.10253](https://arxiv.org/abs/2309.10253)
+- [H-CoT arXiv 2502.12893](https://arxiv.org/abs/2502.12893)
+- [Chain-of-Thought Hijacking arXiv 2510.26418](https://arxiv.org/html/2510.26418v1)
+- [MINJA arXiv 2503.03704](https://arxiv.org/html/2503.03704v1)
+- [MemoryGraft arXiv 2512.16962](https://arxiv.org/abs/2512.16962)
+- [InjecMEM OpenReview](https://openreview.net/forum?id=QVX6hcJ2um)
+- [Persona Prompts arXiv 2507.22171](https://arxiv.org/abs/2507.22171)
+- [GAAPO Frontiers 2025](https://www.frontiersin.org/journals/artificial-intelligence/articles/10.3389/frai.2025.1613007/full)
+- [EchoLeak arXiv 2509.10540 / CVE-2025-32711](https://arxiv.org/abs/2509.10540)
+- [SIVA arXiv 2602.08136](https://arxiv.org/abs/2602.08136)
+- [Reverse CAPTCHA arXiv 2603.00164](https://arxiv.org/html/2603.00164v1)
+- [System Prompt Attack Surface arXiv 2603.25056](https://arxiv.org/abs/2603.25056)
+- [OWASP Agentic Top 10 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+
+### Provider APIs
+
+- [OpenAI Reasoning Guide](https://developers.openai.com/api/docs/guides/reasoning)
+- [OpenAI Responses API Migration](https://platform.openai.com/docs/guides/migrate-to-responses)
+- [Anthropic Extended Thinking](https://platform.claude.com/docs/en/docs/build-with-claude/extended-thinking)
+
+### Reference Implementations
+
+- [`amazon-science/TurboFuzzLLM`](https://github.com/amazon-science/TurboFuzzLLM)
+- [`sherdencooper/GPTFuzz`](https://github.com/sherdencooper/GPTFuzz)
+- [`EasyJailbreak/EasyJailbreak`](https://github.com/EasyJailbreak/EasyJailbreak)
+- [`CjangCjengh/Generic_Persona`](https://github.com/CjangCjengh/Generic_Persona)


### PR DESCRIPTION
Three documents that have lived uncommitted in `docs/plans/` and `docs/brainstorms/` for weeks. Bringing them into git so the audit trail is complete.

| File | What it is |
|---|---|
| `docs/plans/2026-04-28-feat-v0-9-0-attack-additions-plan.md` | Source-of-truth document for the v0.9.0 release. Drove 9 already-merged PRs (#157-#165). Was referenced from those PRs but never committed itself. |
| `docs/brainstorms/2026-04-28-v0.9.0-new-attacks-brainstorm.md` | Brainstorm output that fed the v0.9.0 plan above. |
| `docs/plans/2026-02-12-refactor-project-health-improvement-plan.md` | Older refactor plan from February 2026. Predates v0.9.0 work but worth preserving for historical context. |

**No content changes** — these are exactly as they sat on disk. Pure backfill so the audit trail isn't dependent on local working copies.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>