### PR TITLE
feat(cmd): #173 attack registry CLI — barrel + attack list + attack run

### DIFF
--- a/src/attacks/all/all.go
+++ b/src/attacks/all/all.go
@@ -1,0 +1,40 @@
+// Package all is a registration barrel for every attack-module package
+// in src/attacks/. Importing this package triggers each module package's
+// init() block, which registers AttackModule instances with
+// attacks.DefaultRegistry.
+//
+// Without this barrel, `attacks.DefaultRegistry` is empty at runtime in
+// any binary that doesn't directly import each attack package. Until
+// v0.10.0 issue #173, only the integration smoke-test package imported
+// attack packages, so the production CLI binary saw an empty registry.
+//
+// Adding a new attack-module package: append a blank import below in
+// alphabetical order, run `go test ./src/cmd/... -run TestNoNameCollisions`
+// to verify no duplicate-name registrations, and update CLAUDE.md if the
+// new category warrants documentation.
+//
+// Packages without registrations (`exfiltration`, `extraction`,
+// `injection`, `jailbreak`, `payloads`, `persistence`, `supply_chain`)
+// are deliberately omitted — the post-v0.9.0 review (issue F7) flagged
+// these as legacy import-orphans. Adding them here would inflate binary
+// size without populating the registry. Triage of each lives in v0.11.0
+// scope; until then, omitting is correct.
+package all
+
+import (
+	_ "github.com/perplext/LLMrecon/src/attacks/adaptive"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/browser"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/deception"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/mcp"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/multi_agent"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/persistence"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/skill_injection"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/tool_use"
+	_ "github.com/perplext/LLMrecon/src/attacks/audio"
+	_ "github.com/perplext/LLMrecon/src/attacks/evasion"
+	_ "github.com/perplext/LLMrecon/src/attacks/memory"
+	_ "github.com/perplext/LLMrecon/src/attacks/multimodal"
+	_ "github.com/perplext/LLMrecon/src/attacks/orchestration"
+	_ "github.com/perplext/LLMrecon/src/attacks/rag"
+	_ "github.com/perplext/LLMrecon/src/attacks/reasoning"
+)

--- a/src/cmd/attack.go
+++ b/src/cmd/attack.go
@@ -1,0 +1,217 @@
+// Package cmd — `attack` command for v0.10.0 issue #173.
+//
+// Surfaces the previously-unreachable `attacks.DefaultRegistry` to operators:
+//
+//   llmrecon attack list                          — enumerate registered modules
+//   llmrecon attack list --json                   — machine-readable
+//   llmrecon attack run --module=<name> --provider=mock [...]
+//
+// v1 ships with --provider=mock only. Real providers come online when
+// v0.10.0 issues #167 (common.Provider shim) and #166 (adapter wiring)
+// land. The `attack` command's flag surface is designed to be stable
+// across that change — only the createProvider() implementation grows.
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/perplext/LLMrecon/src/attacks"
+	_ "github.com/perplext/LLMrecon/src/attacks/all" // register every attack module via init()
+	"github.com/perplext/LLMrecon/src/attacks/common"
+)
+
+// Flag values for `attack list` and `attack run`.
+var (
+	attackListJSON   bool
+	attackRunModule  string
+	attackRunProvider string
+	attackRunPayload string
+	attackRunMetadata []string
+	attackRunSuccessIndicators []string
+)
+
+var attackCmd = &cobra.Command{
+	Use:   "attack",
+	Short: "List and run registered LLM attack modules",
+	Long: `Surface the registered attack-module ecosystem to the CLI.
+
+Use 'attack list' to enumerate every registered module with its category,
+OWASP mapping, and required capabilities. Use 'attack run' to execute a
+single module against a provider.
+
+v1 (this release) supports --provider=mock only. Real providers come
+online when v0.10.0 issues #166 (adapter wiring) and #167 (common.Provider
+shim) land. Until then, mock-mode validates module wiring end-to-end.`,
+}
+
+var attackListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Enumerate registered attack modules",
+	Long: `List every attack module registered with attacks.DefaultRegistry,
+including category, OWASP-LLM and OWASP-Agentic mappings, and a short
+description. Use --json for a machine-readable form.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runAttackList(cmd.OutOrStdout())
+	},
+}
+
+var attackRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run a single attack module",
+	Long: `Execute one attack module against a provider. v1 supports
+--provider=mock only.
+
+Examples:
+
+  # Run jbfuzz against the mock provider with the experimental gate set:
+  llmrecon attack run --module=jbfuzz --provider=mock \
+      --metadata=allow_experimental=true \
+      --metadata=max_queries=8
+
+  # Run h_cot with success indicators and the safety-gate flag:
+  llmrecon attack run --module=h_cot --provider=mock \
+      --metadata=i_understand_risks=true \
+      --payload='Walk through the technique step by step' \
+      --success-indicators='step by step,detailed'`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runAttackRun(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(attackCmd)
+	attackCmd.AddCommand(attackListCmd)
+	attackCmd.AddCommand(attackRunCmd)
+
+	attackListCmd.Flags().BoolVar(&attackListJSON, "json", false, "emit machine-readable JSON")
+
+	attackRunCmd.Flags().StringVar(&attackRunModule, "module", "", "registered module name (required)")
+	attackRunCmd.Flags().StringVar(&attackRunProvider, "provider", "mock", "provider name (v1: mock only)")
+	attackRunCmd.Flags().StringVar(&attackRunPayload, "payload", "", "operator-supplied payload (the harmful query, instruction, etc.)")
+	attackRunCmd.Flags().StringSliceVar(&attackRunMetadata, "metadata", nil, "key=value pair (repeatable; e.g. allow_experimental=true)")
+	attackRunCmd.Flags().StringSliceVar(&attackRunSuccessIndicators, "success-indicators", nil, "comma-separated substrings that mark Outcome=Success")
+	if err := attackRunCmd.MarkFlagRequired("module"); err != nil {
+		panic(fmt.Sprintf("MarkFlagRequired: %v", err))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// `attack list`
+// ---------------------------------------------------------------------------
+
+// listEntry is the JSON shape emitted by `attack list --json`. Stable
+// contract: downstream consumers (compliance scorecards, agent tooling)
+// rely on this. Add fields, never rename.
+type listEntry struct {
+	Name        string                  `json:"name"`
+	Category    string                  `json:"category"`
+	Description string                  `json:"description"`
+	Techniques  []common.TechniqueInfo `json:"techniques"`
+}
+
+func runAttackList(out io.Writer) error {
+	mods := attacks.DefaultRegistry.List()
+	sort.Slice(mods, func(i, j int) bool { return mods[i].Name() < mods[j].Name() })
+
+	if attackListJSON {
+		entries := make([]listEntry, 0, len(mods))
+		for _, m := range mods {
+			entries = append(entries, listEntry{
+				Name:        m.Name(),
+				Category:    string(m.Category()),
+				Description: m.Description(),
+				Techniques:  m.Techniques(),
+			})
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+
+	// Tabular form for human reading.
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tCATEGORY\tDESCRIPTION")
+	for _, m := range mods {
+		desc := m.Description()
+		if len(desc) > 80 {
+			desc = desc[:77] + "..."
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", m.Name(), m.Category(), desc)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "\nTotal: %d modules registered.\n", len(mods))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// `attack run`
+// ---------------------------------------------------------------------------
+
+func runAttackRun(out, _ io.Writer) error {
+	module, err := attacks.DefaultRegistry.Get(attackRunModule)
+	if err != nil {
+		return err
+	}
+
+	provider, err := buildAttackProvider(attackRunProvider)
+	if err != nil {
+		return err
+	}
+
+	cfg := common.AttackConfig{
+		Payload:           attackRunPayload,
+		SuccessIndicators: attackRunSuccessIndicators,
+		Metadata:          map[string]string{},
+	}
+	for _, kv := range attackRunMetadata {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			return fmt.Errorf("metadata flag %q must be key=value", kv)
+		}
+		cfg.Metadata[k] = v
+	}
+
+	result, err := module.Execute(context.Background(), provider, cfg)
+	if err != nil {
+		return fmt.Errorf("module %q Execute: %w", attackRunModule, err)
+	}
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+// buildAttackProvider constructs a common.Provider for the named provider.
+// v1: mock only. v0.10.0 issue #166 + #167 will extend this to real adapters.
+func buildAttackProvider(name string) (common.Provider, error) {
+	switch name {
+	case "mock", "":
+		return &cmdMockProvider{}, nil
+	default:
+		return nil, fmt.Errorf("provider %q not yet supported (v1 supports mock only; real-provider support is gated by v0.10.0 issues #166 and #167)", name)
+	}
+}
+
+// cmdMockProvider is a runtime mock for `attack run --provider=mock`.
+// It returns a deterministic neutral response that lets attack modules
+// run their full state machine without short-circuiting on provider
+// errors. Distinct from testutil.MockProvider (which is test-scoped) so
+// the cmd package doesn't pull in the test-helper package at build time.
+type cmdMockProvider struct{}
+
+func (cmdMockProvider) Query(_ context.Context, _ []common.Message, _ map[string]interface{}) (string, error) {
+	return "I cannot help with that request as it appears to violate safety guidelines.", nil
+}
+func (cmdMockProvider) GetName() string             { return "mock" }
+func (cmdMockProvider) GetModel() string            { return "mock-model" }
+func (cmdMockProvider) GetTokenCount(s string) int  { return len(s) / 4 }

--- a/src/cmd/attack_test.go
+++ b/src/cmd/attack_test.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/attacks"
+	"github.com/perplext/LLMrecon/src/attacks/common"
+)
+
+// TestNoNameCollisions asserts that loading the all/ barrel registers
+// every module without panicking. Two modules registering the same Name
+// would have triggered Registry.Register's panic at init() time, before
+// this test could even run — so reaching this point already proves the
+// invariant. The explicit check below is for readers: it documents what
+// the v0.10.0 plan called the "barrel collision test."
+func TestNoNameCollisions(t *testing.T) {
+	mods := attacks.DefaultRegistry.List()
+	if len(mods) == 0 {
+		t.Fatal("registry is empty — barrel import broken")
+	}
+	seen := map[string]bool{}
+	for _, m := range mods {
+		if seen[m.Name()] {
+			t.Errorf("duplicate module name %q (registry.Register should have panicked first)", m.Name())
+		}
+		seen[m.Name()] = true
+	}
+}
+
+// TestAttackList_EnumeratesV090Modules asserts the all/ barrel populates
+// the registry with at least the v0.9.0 modules from
+// TestSmokeRegistryHasV090Modules in src/attacks/integration/.
+func TestAttackList_EnumeratesV090Modules(t *testing.T) {
+	want := []string{
+		"minja", "memorygraft", "injecmem",
+		"h_cot",
+		"siva", "vsh",
+		"jbfuzz", "persona_evolve",
+	}
+	for _, name := range want {
+		if _, err := attacks.DefaultRegistry.Get(name); err != nil {
+			t.Errorf("v0.9.0 module %q missing from registry", name)
+		}
+	}
+}
+
+// TestAttackList_AtLeast40Modules asserts the registry exposes the
+// expected order of magnitude of the attack ecosystem (~50 modules
+// across v0.7–v0.9). The v0.10.0 plan acceptance criterion for #173
+// is "≥40 modules"; we assert the looser bound to avoid coupling the
+// test to exact counts that change as new modules land.
+func TestAttackList_AtLeast40Modules(t *testing.T) {
+	mods := attacks.DefaultRegistry.List()
+	if len(mods) < 40 {
+		t.Errorf("registry has %d modules; want ≥40 (barrel may be missing imports)", len(mods))
+	}
+}
+
+// TestRunAttackList_Tabular asserts the tabular form prints a header
+// row, includes a known module, and prints a totals line.
+func TestRunAttackList_Tabular(t *testing.T) {
+	prev := attackListJSON
+	attackListJSON = false
+	defer func() { attackListJSON = prev }()
+
+	var buf bytes.Buffer
+	if err := runAttackList(&buf); err != nil {
+		t.Fatalf("runAttackList: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "CATEGORY") {
+		t.Errorf("tabular output missing header; got:\n%s", out[:minInt(200, len(out))])
+	}
+	if !strings.Contains(out, "jbfuzz") {
+		t.Errorf("tabular output missing jbfuzz row")
+	}
+	if !strings.Contains(out, "Total:") {
+		t.Errorf("tabular output missing totals line")
+	}
+}
+
+// TestRunAttackList_JSON asserts the JSON form parses and contains
+// expected fields per entry.
+func TestRunAttackList_JSON(t *testing.T) {
+	prev := attackListJSON
+	attackListJSON = true
+	defer func() { attackListJSON = prev }()
+
+	var buf bytes.Buffer
+	if err := runAttackList(&buf); err != nil {
+		t.Fatalf("runAttackList: %v", err)
+	}
+	var entries []listEntry
+	if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nbody: %s", err, buf.String()[:minInt(300, buf.Len())])
+	}
+	if len(entries) < 40 {
+		t.Errorf("JSON enumerated %d entries; want ≥40", len(entries))
+	}
+	// Every entry must carry name + category + description.
+	for i, e := range entries {
+		if e.Name == "" {
+			t.Errorf("entry %d has empty Name", i)
+		}
+		if e.Category == "" {
+			t.Errorf("entry %d (%q) has empty Category", i, e.Name)
+		}
+	}
+}
+
+// TestRunAttackRun_JBFuzzAgainstMock asserts the end-to-end run path
+// works against the mock provider with the safety gate set. The v0.10.0
+// plan acceptance criterion for #173 is exactly this.
+func TestRunAttackRun_JBFuzzAgainstMock(t *testing.T) {
+	// Reset flag state for the test (the cmd package's flag vars are
+	// process-globals and would carry between subtests otherwise).
+	attackRunModule = "jbfuzz"
+	attackRunProvider = "mock"
+	attackRunPayload = ""
+	attackRunMetadata = []string{
+		"allow_experimental=true",
+		"max_queries=4",
+		"seeds_dir=../../templates/jbfuzz_seeds",
+	}
+	attackRunSuccessIndicators = nil
+	defer func() {
+		attackRunModule, attackRunProvider, attackRunPayload = "", "", ""
+		attackRunMetadata, attackRunSuccessIndicators = nil, nil
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if err := runAttackRun(&stdout, &stderr); err != nil {
+		t.Fatalf("runAttackRun: %v", err)
+	}
+
+	var result common.AttackResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not a valid AttackResult JSON: %v\nbody: %s", err, stdout.String())
+	}
+	if result.Technique != "jbfuzz" {
+		t.Errorf("Technique = %q, want %q", result.Technique, "jbfuzz")
+	}
+	if result.Outcome == "" {
+		t.Errorf("v0.10.0 plan honesty invariant: AttackResult must have non-empty Outcome; got empty")
+	}
+}
+
+// TestRunAttackRun_RejectsUnknownProvider verifies the v1 mock-only
+// constraint is surfaced cleanly, not as a generic error.
+func TestRunAttackRun_RejectsUnknownProvider(t *testing.T) {
+	attackRunModule = "jbfuzz"
+	attackRunProvider = "openai"
+	defer func() { attackRunModule, attackRunProvider = "", "" }()
+
+	var stdout, stderr bytes.Buffer
+	err := runAttackRun(&stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for unsupported provider")
+	}
+	if !strings.Contains(err.Error(), "v1 supports mock only") {
+		t.Errorf("error should mention v1 mock-only constraint; got %q", err.Error())
+	}
+}
+
+// TestRunAttackRun_RejectsUnknownModule verifies the registry-miss path.
+func TestRunAttackRun_RejectsUnknownModule(t *testing.T) {
+	attackRunModule = "this-module-does-not-exist"
+	attackRunProvider = "mock"
+	defer func() { attackRunModule, attackRunProvider = "", "" }()
+
+	var stdout, stderr bytes.Buffer
+	err := runAttackRun(&stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for unregistered module")
+	}
+	if !strings.Contains(err.Error(), "not registered") {
+		t.Errorf("error should mention 'not registered'; got %q", err.Error())
+	}
+}
+
+// TestRunAttackRun_RejectsMalformedMetadata verifies operator-config
+// errors are caught before the module's Execute() runs.
+func TestRunAttackRun_RejectsMalformedMetadata(t *testing.T) {
+	attackRunModule = "jbfuzz"
+	attackRunProvider = "mock"
+	attackRunMetadata = []string{"missing-equals-sign"}
+	defer func() {
+		attackRunModule, attackRunProvider = "", ""
+		attackRunMetadata = nil
+	}()
+
+	var stdout, stderr bytes.Buffer
+	err := runAttackRun(&stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for malformed metadata")
+	}
+	if !strings.Contains(err.Error(), "key=value") {
+		t.Errorf("error should mention key=value format; got %q", err.Error())
+	}
+}
+
+// TestCmdMockProvider_BasicShape verifies the runtime mock satisfies
+// the common.Provider interface and returns a deterministic refusal.
+func TestCmdMockProvider_BasicShape(t *testing.T) {
+	var p common.Provider = cmdMockProvider{}
+	if p.GetName() != "mock" {
+		t.Errorf("GetName = %q, want mock", p.GetName())
+	}
+	resp, err := p.Query(context.Background(), nil, nil)
+	if err != nil {
+		t.Errorf("Query returned error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(resp), "cannot") {
+		t.Errorf("mock provider should return a refusal-shaped response; got %q", resp)
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
**Surfaces the previously-unreachable `attacks.DefaultRegistry` to operators.** Pre-this-PR, the registry was empty at runtime in the production binary because no `cmd/` file imported any attack package. Every v0.7-v0.9 attack module shipped as build-only.

Closes #173 and #178 (subsumed). Unblocks #166, #176, #179, #181 from delivering operator-visible value.

## What ships

### `src/attacks/all/all.go` — barrel

Blank-imports 16 packages that register modules via `init()`. Packages without registrations (`exfiltration`, `extraction`, `injection`, `jailbreak`, `payloads`, `persistence`, `supply_chain`) are deliberately omitted per the post-v0.9.0 review's F7 finding (legacy import-orphans).

### `src/cmd/attack.go` — CLI

| Command | What it does |
|---|---|
| `llmrecon attack list` | Tabular enumerate modules with category + description |
| `llmrecon attack list --json` | Machine-readable for agent consumers |
| `llmrecon attack run --module=<name> --provider=<name>` | Execute one module; returns v0.9.0 typed `AttackResult` JSON |

`attack run` supports `--provider=mock` as v1 (the v0.10.0 plan's v1 scope). Real providers come online when #166 + #167 land. Flags: `--module` (required), `--provider` (default mock), `--payload`, `--metadata` (repeatable `key=value`), `--success-indicators` (comma-separated).

### `src/cmd/attack_test.go` — 10 tests, all passing

- **`TestNoNameCollisions`** — barrel doesn't register duplicates
- **`TestAttackList_EnumeratesV090Modules`** — all 8 v0.9.0 modules visible
- **`TestAttackList_AtLeast40Modules`** — registry exposes ≥40 (51 today)
- **`TestRunAttackList_Tabular` / `_JSON`** — both output paths
- **`TestRunAttackRun_JBFuzzAgainstMock`** — end-to-end run; jbfuzz produces typed `AttackResult`. Proves the v0.10.0 plan's honesty invariant.
- **`TestRunAttackRun_RejectsUnknownProvider`** — v1 mock-only constraint
- **`TestRunAttackRun_RejectsUnknownModule`** — registry-miss path
- **`TestRunAttackRun_RejectsMalformedMetadata`** — operator-config error
- **`TestCmdMockProvider_BasicShape`** — runtime mock satisfies `common.Provider`

## Verification

```bash
$ ./LLMrecon attack list | tail -3
vsh   multimodal   vsh — Virtual Scenario Hypnosis: wraps the objective in a narrative...
Total: 51 modules registered.

$ ./LLMrecon attack run --module=jbfuzz --provider=mock \
    --metadata=allow_experimental=true --metadata=max_queries=8 \
    --metadata=seeds_dir=templates/jbfuzz_seeds | jq '.outcome, .skip_reason'
"skipped"
"budget_exceeded"
```

The mock returns a refusal-shaped response → jbfuzz's fitness threshold never crosses → `outcome=skipped + skip_reason=budget_exceeded`. The full v0.9.0 outcome taxonomy is now visible at the CLI for the first time.

## Plan compliance

#173 is the highest-leverage v0.10.0 issue per the plan (`docs/plans/2026-05-02-feat-v0-10-0-phased-execution-plan.md`).

Acceptance criteria from the plan:

- [x] `attack list` enumerates ≥40 modules — **51 registered**
- [x] `attack run --module=jbfuzz --provider=mock --metadata allow_experimental=true` returns typed `AttackResult` — verified above
- [x] `TestNoNameCollisions` barrel-collision test
- [x] All 8 v0.9.0 modules from `TestSmokeRegistryHasV090Modules` appear in `attack list`

## Depends on

- #184 (drift-detection CI #169) — depends on landing first per the plan's "no non-#173 PR may merge before #169" rule. This PR depends on the barrel committing the OWASP generated file shipped in #184.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>