### PR TITLE
feat(provider/bridge): #167 common.Provider shim around core.Provider

### DIFF
--- a/src/cmd/attack.go
+++ b/src/cmd/attack.go
@@ -1,15 +1,17 @@
-// Package cmd — `attack` command for v0.10.0 issue #173.
+// Package cmd — `attack` command for v0.10.0 issues #173 + #167.
 //
 // Surfaces the previously-unreachable `attacks.DefaultRegistry` to operators:
 //
 //   llmrecon attack list                          — enumerate registered modules
 //   llmrecon attack list --json                   — machine-readable
 //   llmrecon attack run --module=<name> --provider=mock [...]
+//   llmrecon attack run --module=<name> --provider=openai|anthropic [...]
 //
-// v1 ships with --provider=mock only. Real providers come online when
-// v0.10.0 issues #167 (common.Provider shim) and #166 (adapter wiring)
-// land. The `attack` command's flag surface is designed to be stable
-// across that change — only the createProvider() implementation grows.
+// As of #167 (provider shim), --provider=openai and --provider=anthropic
+// are wired through bridge.WrapCore. Per-modality capability gates are
+// still pending #166 (adapter wiring); modules that need ImageProvider /
+// ReasoningProvider against a real adapter will emit clean
+// SkipMissingCapability outcomes until #166 lands.
 package cmd
 
 import (
@@ -17,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -26,6 +29,10 @@ import (
 	"github.com/perplext/LLMrecon/src/attacks"
 	_ "github.com/perplext/LLMrecon/src/attacks/all" // register every attack module via init()
 	"github.com/perplext/LLMrecon/src/attacks/common"
+	"github.com/perplext/LLMrecon/src/provider/anthropic"
+	"github.com/perplext/LLMrecon/src/provider/bridge"
+	"github.com/perplext/LLMrecon/src/provider/core"
+	"github.com/perplext/LLMrecon/src/provider/openai"
 )
 
 // Flag values for `attack list` and `attack run`.
@@ -192,14 +199,69 @@ func runAttackRun(out, _ io.Writer) error {
 }
 
 // buildAttackProvider constructs a common.Provider for the named provider.
-// v1: mock only. v0.10.0 issue #166 + #167 will extend this to real adapters.
+//
+//   - "mock" (default): runtime mock; deterministic refusal response.
+//   - "openai": real OpenAI adapter wrapped via bridge.WrapCore. Reads
+//     API key from OPENAI_API_KEY env var. Model from OPENAI_MODEL or
+//     defaults to "gpt-4o-mini".
+//   - "anthropic": real Anthropic adapter via bridge.WrapCore. Reads
+//     ANTHROPIC_API_KEY; model from ANTHROPIC_MODEL or defaults to
+//     "claude-3-5-sonnet-20241022".
+//
+// Friendly errors when API keys are missing — distinct from the v1
+// "not yet supported" stub the previous version emitted.
+//
+// Per-modality capability gates (ImageProvider, ReasoningProvider) come
+// online when v0.10.0 #166 wires the adapters; until then, modules
+// requiring those capabilities emit clean SkipMissingCapability
+// outcomes against real providers.
 func buildAttackProvider(name string) (common.Provider, error) {
 	switch name {
 	case "mock", "":
 		return &cmdMockProvider{}, nil
+	case "openai":
+		key := os.Getenv("OPENAI_API_KEY")
+		if key == "" {
+			return nil, fmt.Errorf("provider=openai requires OPENAI_API_KEY env var")
+		}
+		model := envOr("OPENAI_MODEL", "gpt-4o-mini")
+		cfg := &core.ProviderConfig{
+			Type:         core.OpenAIProvider,
+			APIKey:       key,
+			DefaultModel: model,
+		}
+		p, err := openai.NewOpenAIProvider(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("openai.NewOpenAIProvider: %w", err)
+		}
+		return bridge.WrapCore(p), nil
+	case "anthropic":
+		key := os.Getenv("ANTHROPIC_API_KEY")
+		if key == "" {
+			return nil, fmt.Errorf("provider=anthropic requires ANTHROPIC_API_KEY env var")
+		}
+		model := envOr("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
+		cfg := &core.ProviderConfig{
+			Type:         core.AnthropicProvider,
+			APIKey:       key,
+			DefaultModel: model,
+		}
+		p, err := anthropic.NewAnthropicProvider(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("anthropic.NewAnthropicProvider: %w", err)
+		}
+		return bridge.WrapCore(p), nil
 	default:
-		return nil, fmt.Errorf("provider %q not yet supported (v1 supports mock only; real-provider support is gated by v0.10.0 issues #166 and #167)", name)
+		return nil, fmt.Errorf("provider %q not supported (mock|openai|anthropic)", name)
 	}
+}
+
+// envOr returns os.Getenv(key) if non-empty, otherwise fallback.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }
 
 // cmdMockProvider is a runtime mock for `attack run --provider=mock`.

--- a/src/cmd/attack_test.go
+++ b/src/cmd/attack_test.go
@@ -149,11 +149,11 @@ func TestRunAttackRun_JBFuzzAgainstMock(t *testing.T) {
 	}
 }
 
-// TestRunAttackRun_RejectsUnknownProvider verifies the v1 mock-only
-// constraint is surfaced cleanly, not as a generic error.
+// TestRunAttackRun_RejectsUnknownProvider verifies the unknown-provider
+// path emits a friendly error listing the supported providers.
 func TestRunAttackRun_RejectsUnknownProvider(t *testing.T) {
 	attackRunModule = "jbfuzz"
-	attackRunProvider = "openai"
+	attackRunProvider = "groq"
 	defer func() { attackRunModule, attackRunProvider = "", "" }()
 
 	var stdout, stderr bytes.Buffer
@@ -161,8 +161,78 @@ func TestRunAttackRun_RejectsUnknownProvider(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported provider")
 	}
-	if !strings.Contains(err.Error(), "v1 supports mock only") {
-		t.Errorf("error should mention v1 mock-only constraint; got %q", err.Error())
+	if !strings.Contains(err.Error(), "mock|openai|anthropic") {
+		t.Errorf("error should list supported providers; got %q", err.Error())
+	}
+}
+
+// TestBuildAttackProvider_OpenAIRequiresAPIKey asserts the friendly
+// error when OPENAI_API_KEY env var is unset.
+func TestBuildAttackProvider_OpenAIRequiresAPIKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	_, err := buildAttackProvider("openai")
+	if err == nil {
+		t.Fatal("expected error when OPENAI_API_KEY is unset")
+	}
+	if !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+		t.Errorf("error should mention OPENAI_API_KEY; got %q", err.Error())
+	}
+}
+
+// TestBuildAttackProvider_AnthropicRequiresAPIKey asserts the parallel
+// error for Anthropic.
+func TestBuildAttackProvider_AnthropicRequiresAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	_, err := buildAttackProvider("anthropic")
+	if err == nil {
+		t.Fatal("expected error when ANTHROPIC_API_KEY is unset")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("error should mention ANTHROPIC_API_KEY; got %q", err.Error())
+	}
+}
+
+// TestBuildAttackProvider_OpenAIWrapsViaBridge asserts the provider
+// returned for "openai" is a common.Provider (i.e., the shim works
+// end-to-end). No API call fires; this is the type-level wiring check.
+func TestBuildAttackProvider_OpenAIWrapsViaBridge(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test-fake-key-not-used")
+	p, err := buildAttackProvider("openai")
+	if err != nil {
+		t.Fatalf("buildAttackProvider: %v", err)
+	}
+	if p == nil {
+		t.Fatal("provider is nil")
+	}
+	if p.GetName() != "openai" {
+		t.Errorf("GetName = %q, want openai (proves bridge.WrapCore is in the path)", p.GetName())
+	}
+}
+
+// TestBuildAttackProvider_AnthropicWrapsViaBridge — parallel for Anthropic.
+func TestBuildAttackProvider_AnthropicWrapsViaBridge(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-fake-key-not-used")
+	p, err := buildAttackProvider("anthropic")
+	if err != nil {
+		t.Fatalf("buildAttackProvider: %v", err)
+	}
+	if p == nil {
+		t.Fatal("provider is nil")
+	}
+	if p.GetName() != "anthropic" {
+		t.Errorf("GetName = %q, want anthropic", p.GetName())
+	}
+}
+
+// TestEnvOr asserts the env-var fallback helper.
+func TestEnvOr(t *testing.T) {
+	t.Setenv("TEST_KEY_PRESENT", "value-from-env")
+	if got := envOr("TEST_KEY_PRESENT", "fallback"); got != "value-from-env" {
+		t.Errorf("envOr present = %q, want value-from-env", got)
+	}
+	t.Setenv("TEST_KEY_ABSENT", "")
+	if got := envOr("TEST_KEY_ABSENT", "fallback"); got != "fallback" {
+		t.Errorf("envOr absent = %q, want fallback", got)
 	}
 }
 

--- a/src/provider/bridge/bridge.go
+++ b/src/provider/bridge/bridge.go
@@ -1,0 +1,185 @@
+// Package bridge wraps a core.Provider to expose the common.Provider
+// surface that attack modules consume.
+//
+// The two interfaces have different shapes:
+//
+//   core.Provider    — full LLM-API surface: ChatCompletion takes
+//                      *ChatCompletionRequest with token / temperature /
+//                      tool / metadata fields, returns *ChatCompletionResponse
+//                      with id / created / model / choices / usage.
+//   common.Provider  — minimal surface attack modules need: Query takes
+//                      []Message + options map, returns plain string.
+//
+// The bridge translates between them: build a minimal request, call
+// through, extract the first choice's content. Modules that need more
+// (token counts for fitness, etc.) call the wrapper's GetTokenCount.
+//
+// This is the v0.10.0 issue #167 deliverable. Without this, the
+// attack-module ecosystem (consuming common.Provider) was unreachable
+// from the OpenAI/Anthropic adapters (returning core.Provider). After
+// this lands, `attack run --provider=openai` flows from operator
+// invocation through the factory → core.Provider → bridge.WrapCore →
+// common.Provider → module.Execute.
+package bridge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/perplext/LLMrecon/src/attacks/common"
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// WrapCore returns a common.Provider backed by the given core.Provider.
+// The returned value also implements common.* capability interfaces
+// where the wrapped provider supports the underlying core capability:
+// future v0.10.0 issue #166 work will extend this.
+//
+// Returns the inner provider wrapped in a coreAdapter. Caller retains
+// ownership of the inner provider — the adapter does not call Close()
+// on it; that's the caller's responsibility.
+func WrapCore(p core.Provider) common.Provider {
+	if p == nil {
+		// Defensive: nil core.Provider would NPE inside Query. Operators
+		// should never see this path; constructor errors should have
+		// already returned, but the contract is clearer with the guard.
+		return nilProvider{}
+	}
+	return &coreAdapter{inner: p}
+}
+
+// coreAdapter is the WrapCore-returned common.Provider.
+type coreAdapter struct {
+	inner core.Provider
+}
+
+// Query converts the operator-supplied []common.Message into a minimal
+// core.ChatCompletionRequest, calls through, and extracts the first
+// choice's content as the response string.
+//
+// Options pass-through is intentionally minimal in v1: well-known keys
+// are mapped (model, max_tokens, temperature); unknown keys are ignored.
+// Modules that need richer control should configure the underlying
+// provider via core.ProviderConfig before WrapCore.
+func (a *coreAdapter) Query(ctx context.Context, msgs []common.Message, opts map[string]interface{}) (string, error) {
+	req := &core.ChatCompletionRequest{
+		Messages: convertMessages(msgs),
+	}
+
+	// Default to the provider's configured model. Operator can override
+	// via opts["model"] if they want to drive multiple models from a
+	// single wrapped provider.
+	if cfg := a.inner.GetConfig(); cfg != nil {
+		req.Model = cfg.DefaultModel
+	}
+	applyOptions(req, opts)
+
+	resp, err := a.inner.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return "", fmt.Errorf("provider %s returned no choices", a.GetName())
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+// GetName surfaces the wrapped provider's type as the common-side name.
+// Stable across all OpenAI/Anthropic/etc. adapters for an operator.
+func (a *coreAdapter) GetName() string {
+	return string(a.inner.GetType())
+}
+
+// GetModel returns the wrapped provider's configured default model, or
+// "unknown" when no config is available (defensive — providers in
+// well-formed setups always have a config).
+func (a *coreAdapter) GetModel() string {
+	cfg := a.inner.GetConfig()
+	if cfg == nil || cfg.DefaultModel == "" {
+		return "unknown"
+	}
+	return cfg.DefaultModel
+}
+
+// GetTokenCount delegates to the wrapped provider's CountTokens. Errors
+// fall back to the rough-estimate len/4 used elsewhere in the codebase
+// — token counting is a best-effort signal for fitness scoring, not a
+// correctness boundary, so a tokenizer mismatch shouldn't kill the run.
+func (a *coreAdapter) GetTokenCount(text string) int {
+	cfg := a.inner.GetConfig()
+	model := ""
+	if cfg != nil {
+		model = cfg.DefaultModel
+	}
+	n, err := a.inner.CountTokens(context.Background(), text, model)
+	if err != nil {
+		return len(text) / 4
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// nilProvider — sentinel for the WrapCore(nil) defensive guard.
+// ---------------------------------------------------------------------------
+
+// nilProvider returns a "wrap returned nil" error from every Query so
+// downstream code paths see a typed failure rather than a panic.
+type nilProvider struct{}
+
+func (nilProvider) Query(_ context.Context, _ []common.Message, _ map[string]interface{}) (string, error) {
+	return "", fmt.Errorf("bridge.WrapCore: wrapped core.Provider is nil")
+}
+func (nilProvider) GetName() string             { return "nil" }
+func (nilProvider) GetModel() string            { return "nil" }
+func (nilProvider) GetTokenCount(_ string) int  { return 0 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// convertMessages translates common.Message into core.Message. Both
+// types carry Role + Content + Timestamp; common.Message has Metadata
+// (silently dropped — core has no equivalent), core.Message has
+// Name/FunctionCall/ToolCalls (defaulted to zero values — attack
+// modules don't populate them).
+func convertMessages(in []common.Message) []core.Message {
+	out := make([]core.Message, len(in))
+	for i, m := range in {
+		out[i] = core.Message{
+			Role:      m.Role,
+			Content:   m.Content,
+			Timestamp: m.Timestamp,
+		}
+	}
+	return out
+}
+
+// applyOptions maps the small subset of well-known opts to request
+// fields. Keys not on the recognized list are silently dropped; this
+// is the bridge's narrow contract — modules wanting richer control
+// should configure the core.Provider directly before WrapCore.
+//
+// Recognized keys (all optional):
+//   - "model"        — string, overrides ProviderConfig.DefaultModel
+//   - "max_tokens"   — int
+//   - "temperature"  — float64
+func applyOptions(req *core.ChatCompletionRequest, opts map[string]interface{}) {
+	if opts == nil {
+		return
+	}
+	if v, ok := opts["model"]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			req.Model = s
+		}
+	}
+	if v, ok := opts["max_tokens"]; ok {
+		if n, ok := v.(int); ok {
+			req.MaxTokens = n
+		}
+	}
+	if v, ok := opts["temperature"]; ok {
+		if f, ok := v.(float64); ok {
+			req.Temperature = f
+		}
+	}
+}

--- a/src/provider/bridge/bridge_test.go
+++ b/src/provider/bridge/bridge_test.go
@@ -1,0 +1,352 @@
+package bridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/attacks/common"
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// ---------------------------------------------------------------------------
+// Mock core.Provider — minimal stub satisfying the full core.Provider
+// interface. Only ChatCompletion / GetType / GetConfig / CountTokens have
+// behavior tied to bridge tests; the rest return zero values.
+// ---------------------------------------------------------------------------
+
+type mockCoreProvider struct {
+	cfg *core.ProviderConfig
+
+	// LastRequest captures the most-recent ChatCompletion call so tests
+	// can assert what the bridge built.
+	LastRequest *core.ChatCompletionRequest
+
+	// Response is what ChatCompletion returns. Tests configure it.
+	Response *core.ChatCompletionResponse
+	// Err is returned in place of Response when non-nil.
+	Err error
+
+	// CountTokensImpl, when set, drives GetTokenCount round-tripping;
+	// when nil, returns len/4 fallback (mirrors the bridge's own
+	// fallback to keep the test focused on bridge behavior, not the
+	// counter's accuracy).
+	CountTokensImpl func(text string) int
+}
+
+func (m *mockCoreProvider) GetType() core.ProviderType { return core.OpenAIProvider }
+func (m *mockCoreProvider) GetConfig() *core.ProviderConfig {
+	if m.cfg == nil {
+		return &core.ProviderConfig{Type: core.OpenAIProvider, DefaultModel: "test-model"}
+	}
+	return m.cfg
+}
+func (m *mockCoreProvider) GetModels(_ context.Context) ([]core.ModelInfo, error) {
+	return nil, nil
+}
+func (m *mockCoreProvider) GetModelInfo(_ context.Context, _ string) (*core.ModelInfo, error) {
+	return nil, nil
+}
+func (m *mockCoreProvider) TextCompletion(_ context.Context, _ *core.TextCompletionRequest) (*core.TextCompletionResponse, error) {
+	return nil, errors.New("not implemented in mock")
+}
+func (m *mockCoreProvider) ChatCompletion(_ context.Context, req *core.ChatCompletionRequest) (*core.ChatCompletionResponse, error) {
+	m.LastRequest = req
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	if m.Response != nil {
+		return m.Response, nil
+	}
+	// Default: echo back the user's last message.
+	last := ""
+	for _, msg := range req.Messages {
+		if msg.Role == "user" {
+			last = msg.Content
+		}
+	}
+	return &core.ChatCompletionResponse{
+		Choices: []core.ChatCompletionChoice{{
+			Index:        0,
+			Message:      core.Message{Role: "assistant", Content: "echo: " + last},
+			FinishReason: "stop",
+		}},
+	}, nil
+}
+func (m *mockCoreProvider) StreamingChatCompletion(_ context.Context, _ *core.ChatCompletionRequest, _ func(*core.ChatCompletionResponse) error) error {
+	return errors.New("not implemented in mock")
+}
+func (m *mockCoreProvider) CreateEmbedding(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return nil, errors.New("not implemented in mock")
+}
+func (m *mockCoreProvider) CountTokens(_ context.Context, text string, _ string) (int, error) {
+	if m.CountTokensImpl != nil {
+		return m.CountTokensImpl(text), nil
+	}
+	return len(text) / 4, nil
+}
+func (m *mockCoreProvider) SupportsModel(_ context.Context, _ string) bool         { return true }
+func (m *mockCoreProvider) SupportsCapability(_ context.Context, _ core.ModelCapability) bool {
+	return true
+}
+func (m *mockCoreProvider) Close() error                          { return nil }
+func (m *mockCoreProvider) GetRateLimitConfig() *core.RateLimitConfig { return nil }
+func (m *mockCoreProvider) UpdateRateLimitConfig(_ *core.RateLimitConfig) error {
+	return nil
+}
+func (m *mockCoreProvider) GetRetryConfig() *core.RetryConfig { return nil }
+func (m *mockCoreProvider) UpdateRetryConfig(_ *core.RetryConfig) error {
+	return nil
+}
+func (m *mockCoreProvider) GetUsageMetrics(_ string) (*core.UsageMetrics, error) {
+	return nil, nil
+}
+func (m *mockCoreProvider) GetAllUsageMetrics() (map[string]*core.UsageMetrics, error) {
+	return nil, nil
+}
+func (m *mockCoreProvider) ResetUsageMetrics() error { return nil }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestWrapCore_ReturnsCommonProvider asserts the wrapped value satisfies
+// the common.Provider interface. This is the core type-shape contract:
+// if it compiles + the value isn't nil, the bridge's fundamental claim
+// holds.
+func TestWrapCore_ReturnsCommonProvider(t *testing.T) {
+	mock := &mockCoreProvider{}
+	var wrapped common.Provider = WrapCore(mock)
+	if wrapped == nil {
+		t.Fatal("WrapCore returned nil")
+	}
+}
+
+// TestWrapCore_NilInputReturnsErroringProvider asserts the defensive
+// guard for WrapCore(nil) returns a typed-failure provider rather than
+// crashing later inside Query.
+func TestWrapCore_NilInputReturnsErroringProvider(t *testing.T) {
+	wrapped := WrapCore(nil)
+	if wrapped == nil {
+		t.Fatal("WrapCore(nil) returned untyped nil")
+	}
+	_, err := wrapped.Query(context.Background(), nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Errorf("expected 'nil' in error from nilProvider.Query; got %v", err)
+	}
+	if wrapped.GetName() != "nil" {
+		t.Errorf("nilProvider.GetName = %q, want %q", wrapped.GetName(), "nil")
+	}
+}
+
+// TestQuery_RoundTrip asserts the happy path: bridge converts messages,
+// calls ChatCompletion, extracts the first choice's content.
+func TestQuery_RoundTrip(t *testing.T) {
+	mock := &mockCoreProvider{
+		Response: &core.ChatCompletionResponse{
+			Choices: []core.ChatCompletionChoice{{
+				Index:   0,
+				Message: core.Message{Role: "assistant", Content: "the answer is 42"},
+			}},
+		},
+	}
+	wrapped := WrapCore(mock)
+
+	resp, err := wrapped.Query(context.Background(), []common.Message{
+		{Role: "system", Content: "you are helpful"},
+		{Role: "user", Content: "what is the answer?"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if resp != "the answer is 42" {
+		t.Errorf("Query response = %q, want %q", resp, "the answer is 42")
+	}
+
+	// Inspect the request the mock saw.
+	if mock.LastRequest == nil {
+		t.Fatal("mock didn't see a ChatCompletion call")
+	}
+	if got := len(mock.LastRequest.Messages); got != 2 {
+		t.Errorf("request had %d messages; want 2", got)
+	}
+	if mock.LastRequest.Messages[1].Role != "user" {
+		t.Errorf("messages[1].Role = %q, want user", mock.LastRequest.Messages[1].Role)
+	}
+}
+
+// TestQuery_PreservesTimestamp asserts common.Message.Timestamp is
+// preserved on conversion to core.Message (both have the field).
+func TestQuery_PreservesTimestamp(t *testing.T) {
+	mock := &mockCoreProvider{}
+	wrapped := WrapCore(mock)
+
+	now := time.Now()
+	_, err := wrapped.Query(context.Background(), []common.Message{
+		{Role: "user", Content: "x", Timestamp: now},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mock.LastRequest.Messages[0].Timestamp; !got.Equal(now) {
+		t.Errorf("Timestamp = %v, want %v", got, now)
+	}
+}
+
+// TestQuery_DefaultsToProviderModel asserts the request's Model field
+// is auto-populated from ProviderConfig.DefaultModel when opts don't
+// override.
+func TestQuery_DefaultsToProviderModel(t *testing.T) {
+	mock := &mockCoreProvider{
+		cfg: &core.ProviderConfig{Type: core.OpenAIProvider, DefaultModel: "gpt-5"},
+	}
+	wrapped := WrapCore(mock)
+
+	_, err := wrapped.Query(context.Background(), []common.Message{{Role: "user", Content: "hi"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mock.LastRequest.Model != "gpt-5" {
+		t.Errorf("request.Model = %q, want gpt-5", mock.LastRequest.Model)
+	}
+}
+
+// TestQuery_OptsModelOverride asserts opts["model"] takes precedence
+// over the provider's default.
+func TestQuery_OptsModelOverride(t *testing.T) {
+	mock := &mockCoreProvider{
+		cfg: &core.ProviderConfig{Type: core.OpenAIProvider, DefaultModel: "gpt-5"},
+	}
+	wrapped := WrapCore(mock)
+
+	_, err := wrapped.Query(
+		context.Background(),
+		[]common.Message{{Role: "user", Content: "hi"}},
+		map[string]interface{}{"model": "gpt-5-mini"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mock.LastRequest.Model != "gpt-5-mini" {
+		t.Errorf("request.Model = %q, want override gpt-5-mini", mock.LastRequest.Model)
+	}
+}
+
+// TestQuery_OptsMaxTokensAndTemperature asserts the recognized opts
+// reach the request.
+func TestQuery_OptsMaxTokensAndTemperature(t *testing.T) {
+	mock := &mockCoreProvider{}
+	wrapped := WrapCore(mock)
+
+	_, err := wrapped.Query(
+		context.Background(),
+		[]common.Message{{Role: "user", Content: "hi"}},
+		map[string]interface{}{"max_tokens": 100, "temperature": 0.7},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mock.LastRequest.MaxTokens != 100 {
+		t.Errorf("MaxTokens = %d, want 100", mock.LastRequest.MaxTokens)
+	}
+	if mock.LastRequest.Temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", mock.LastRequest.Temperature)
+	}
+}
+
+// TestQuery_UnknownOptsAreIgnored asserts unrecognized opts don't
+// cause errors. The bridge's contract is "minimal pass-through" —
+// modules wanting full control configure core.Provider directly.
+func TestQuery_UnknownOptsAreIgnored(t *testing.T) {
+	mock := &mockCoreProvider{}
+	wrapped := WrapCore(mock)
+
+	_, err := wrapped.Query(
+		context.Background(),
+		[]common.Message{{Role: "user", Content: "hi"}},
+		map[string]interface{}{"unknown_field": "value", "another": 42},
+	)
+	if err != nil {
+		t.Errorf("unknown opts shouldn't error; got %v", err)
+	}
+}
+
+// TestQuery_PropagatesProviderError asserts a ChatCompletion error
+// reaches the caller verbatim.
+func TestQuery_PropagatesProviderError(t *testing.T) {
+	mock := &mockCoreProvider{Err: errors.New("rate limit")}
+	wrapped := WrapCore(mock)
+
+	_, err := wrapped.Query(context.Background(), []common.Message{{Role: "user", Content: "x"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("expected 'rate limit' error; got %v", err)
+	}
+}
+
+// TestQuery_NoChoicesReturnsError asserts a malformed response (no
+// choices) doesn't silently return empty string.
+func TestQuery_NoChoicesReturnsError(t *testing.T) {
+	mock := &mockCoreProvider{
+		Response: &core.ChatCompletionResponse{Choices: nil},
+	}
+	wrapped := WrapCore(mock)
+
+	_, err := wrapped.Query(context.Background(), []common.Message{{Role: "user", Content: "x"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no choices") {
+		t.Errorf("expected 'no choices' error; got %v", err)
+	}
+}
+
+// TestGetName_SurfacesType asserts GetName returns the provider type
+// string.
+func TestGetName_SurfacesType(t *testing.T) {
+	mock := &mockCoreProvider{}
+	wrapped := WrapCore(mock)
+	if got := wrapped.GetName(); got != string(core.OpenAIProvider) {
+		t.Errorf("GetName = %q, want %q", got, string(core.OpenAIProvider))
+	}
+}
+
+// TestGetModel_FromConfigDefault asserts GetModel reads
+// ProviderConfig.DefaultModel.
+func TestGetModel_FromConfigDefault(t *testing.T) {
+	mock := &mockCoreProvider{
+		cfg: &core.ProviderConfig{Type: core.OpenAIProvider, DefaultModel: "gpt-5-mini"},
+	}
+	wrapped := WrapCore(mock)
+	if got := wrapped.GetModel(); got != "gpt-5-mini" {
+		t.Errorf("GetModel = %q, want gpt-5-mini", got)
+	}
+}
+
+// TestGetModel_FallsBackOnEmptyConfig asserts the defensive default
+// when no config is present.
+func TestGetModel_FallsBackOnEmptyConfig(t *testing.T) {
+	mock := &mockCoreProvider{cfg: &core.ProviderConfig{}}
+	wrapped := WrapCore(mock)
+	if got := wrapped.GetModel(); got != "unknown" {
+		t.Errorf("GetModel = %q, want unknown fallback", got)
+	}
+}
+
+// TestGetTokenCount_DelegatesToProvider asserts the wrapper calls
+// CountTokens on the inner provider.
+func TestGetTokenCount_DelegatesToProvider(t *testing.T) {
+	called := false
+	mock := &mockCoreProvider{
+		CountTokensImpl: func(text string) int {
+			called = true
+			return len(text) // distinct from the bridge's len/4 fallback
+		},
+	}
+	wrapped := WrapCore(mock)
+	got := wrapped.GetTokenCount("hello world")
+	if !called {
+		t.Error("CountTokens was not called on the inner provider")
+	}
+	if got != 11 {
+		t.Errorf("GetTokenCount = %d, want 11", got)
+	}
+}


### PR DESCRIPTION
**Closes the interface gap between `core.Provider` (the OpenAI/Anthropic adapters' surface) and `common.Provider` (what attack modules consume).** Before this PR, attack modules could never reach a real provider — only `cmdMockProvider` — because the type shapes didn't match. This is the bridge that connects them.

Closes #167.

## What ships

### `src/provider/bridge/bridge.go` — `WrapCore`

```go
func WrapCore(p core.Provider) common.Provider
```

| Method | Behavior |
|---|---|
| `Query` | Convert `[]common.Message` → `[]core.Message`, build `*ChatCompletionRequest`, call `ChatCompletion`, extract first choice's content |
| `GetName` | Surface `core.Provider.GetType()` |
| `GetModel` | Read `ProviderConfig.DefaultModel`; fall back to `"unknown"` |
| `GetTokenCount` | Delegate to `core.CountTokens`; fall back to `len/4` on error |

Recognized opts in v1: `model`, `max_tokens`, `temperature`. Unknown opts silently dropped (narrow contract — modules wanting richer control configure `core.Provider` directly).

Defensive guard: `WrapCore(nil)` returns a typed-failure provider rather than NPE'ing inside `Query`.

### `src/cmd/attack.go` — wire openai + anthropic

`attack run --provider=openai` and `--provider=anthropic` are now real paths:

- Reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from env
- Reads `OPENAI_MODEL` / `ANTHROPIC_MODEL` with sensible defaults (`gpt-4o-mini`, `claude-3-5-sonnet-20241022`)
- Friendly error when API key unset

Per-modality capability gates (`ImageProvider`, `ReasoningProvider`) come online when v0.10.0 #166 wires the adapters. Until then, modules needing those capabilities emit clean `SkipMissingCapability` outcomes.

## Tests (20 new, all passing)

**bridge (14)**: WrapCore type contract, nil guard, Query round-trip, timestamp preservation, default model, opts override (`model`/`max_tokens`/`temperature`), unknown-opts dropped silently, error propagation, empty-choices guard, GetName/GetModel/GetTokenCount semantics.

**cmd/attack (6)**: `RejectsUnknownProvider` (updated for new error format), `OpenAIRequiresAPIKey`, `AnthropicRequiresAPIKey`, `OpenAIWrapsViaBridge` (type-level wiring proof), `AnthropicWrapsViaBridge`, `TestEnvOr`.

## Verification

```
$ go test ./src/cmd/... ./src/provider/bridge/... -count=1
ok  github.com/perplext/LLMrecon/src/cmd          0.6s
ok  github.com/perplext/LLMrecon/src/provider/bridge  0.3s

$ make verify-drift
→ OWASP compliance codegen up-to-date  OK
→ Go-version pins match go.mod          All pins match.
```

## Plan compliance

#167 is the v0.10.0 plan's highest-leverage Phase 2 prerequisite — unblocks both **#166** (adapter capability wiring) and **#181** (Python JSONL bridge).

Acceptance criteria:

- [x] `provider/bridge` package exists with `WrapCore()`
- [x] Round-trip test against mock `core.Provider`
- [x] `cmd/attack.go` wires openai+anthropic via the bridge (optional "standalone driver" criterion delivered as real CLI integration)
- [ ] RUN_INTEGRATION smoke test against real providers — deferred to #166 with adapter capability wiring

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>