### PR TITLE
fix(cmd/update): #174 Tier 1 — stop fake-success in update apply

### DIFF
--- a/src/cmd/update_apply.go
+++ b/src/cmd/update_apply.go
@@ -174,6 +174,12 @@ selective updates and automatic backup creation.`,
 		}
 		defer os.RemoveAll(tempDir)
 
+		// Track per-update apply failures so we can exit non-zero at the
+		// end if any update failed to land. Mirrors how the Tier 1
+		// "not implemented" stubs surface: each is an error that should
+		// signal failure, not be papered over with a generic completion message.
+		applyErrorCount := 0
+
 		// Download and apply updates
 		for _, u := range updates {
 			fmt.Printf("\nUpdating %s to version %s...\n", u.Component, u.LatestVersion.String())
@@ -221,12 +227,22 @@ selective updates and automatic backup creation.`,
 
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error applying update: %v\n", err)
+				applyErrorCount++
 				continue
 			}
 
 			fmt.Printf("Successfully updated %s to version %s.\n", u.Component, u.LatestVersion.String())
 		}
 
+		// v0.10.0 #174 Tier 1: any apply path that errored (including the
+		// "not implemented" stubs) means the on-disk state did NOT change
+		// to the version the operator asked for. Exit non-zero so any
+		// surrounding shell/CI workflow notices, instead of trusting a
+		// 0-exit-with-error-printed signal.
+		if applyErrorCount > 0 {
+			fmt.Fprintf(os.Stderr, "\nUpdate process completed with %d error(s); see above. No on-disk changes were made for the failing components.\n", applyErrorCount)
+			os.Exit(1)
+		}
 		fmt.Println("\nUpdate process completed.")
 	},
 }
@@ -241,55 +257,46 @@ func init() {
 	updateApplyCmd.Flags().Bool("backup", false, "Create backup before applying updates")
 }
 
-// createBackup creates a backup of the current installation
+// applyNotImplementedHint is the standard guidance string operators see
+// when an update-apply path is unimplemented in this release. Centralized
+// so the message is consistent across the four stubs and easy to update
+// once Tier 2 (#174) lands real implementations.
+const applyNotImplementedHint = "on-disk update apply not implemented in this version; download bundle to %q and extract manually, or wait for v0.10.0 #174 Tier 2"
+
+// createBackup creates a backup of the current installation.
+//
+// v0.10.0 #174 Tier 1: returns a non-nil error rather than silently no-op'ing.
+// Tier 2 will implement (cp -a of install dir with timestamp suffix). Operator
+// who explicitly passed --backup gets a hard failure rather than a fake
+// "Backup created successfully" message they shouldn't trust.
 func createBackup(cfg *config.Config) error {
-	// This is a placeholder implementation
-	// In a real implementation, this would:
-	// 1. Create a timestamped backup directory
-	// 2. Copy the current binary
-	// 3. Archive the templates directory
-	// 4. Archive the modules directory
-	// 5. Save the current configuration
-
-	fmt.Println("Backup functionality not implemented in this version.")
-	return nil
+	return fmt.Errorf("createBackup: not implemented in this version (deferred to v0.10.0 #174 Tier 2)")
 }
 
-// applyCoreBinaryUpdate applies an update to the core binary
+// applyCoreBinaryUpdate applies an update to the core binary.
+//
+// v0.10.0 #174 Tier 1: stops printing fake success. Binary self-replace
+// is high-risk (atomic swap of running process's binary, Windows file
+// locks, permission preservation) and is deferred to v0.11.0 — the
+// templates/modules paths in Tier 2 are lower-risk and ship first.
 func applyCoreBinaryUpdate(downloadPath string) error {
-	// This is a placeholder implementation
-	// In a real implementation, this would:
-	// 1. Extract the downloaded archive
-	// 2. Replace the current binary with the new one
-	// 3. Ensure proper permissions are set
-	// 4. Handle platform-specific details (e.g., Windows file locks)
-
-	fmt.Println("Core binary update not implemented in this version.")
-	return nil
+	return fmt.Errorf("applyCoreBinaryUpdate: not implemented in this version (binary self-replace deferred; see v0.10.0 #174 Tier 1; download is at %q)", downloadPath)
 }
 
-// applyTemplatesUpdate applies an update to the templates
+// applyTemplatesUpdate applies an update to the templates directory.
+//
+// v0.10.0 #174 Tier 1: returns error instead of nil so the caller's
+// "Successfully updated" message is suppressed. Tier 2 will implement
+// via ZIP extract + atomic os.Rename over the templates dir.
 func applyTemplatesUpdate(downloadPath, templatesDir string) error {
-	// This is a placeholder implementation
-	// In a real implementation, this would:
-	// 1. Extract the downloaded archive to a temporary location
-	// 2. Validate the template structure
-	// 3. Backup existing templates
-	// 4. Copy new templates to the templates directory
-
-	fmt.Println("Templates update not implemented in this version.")
-	return nil
+	return fmt.Errorf(applyNotImplementedHint+" (component=templates, target=%q)", downloadPath, templatesDir)
 }
 
-// applyModuleUpdate applies an update to a specific module
+// applyModuleUpdate applies an update to a specific module.
+//
+// v0.10.0 #174 Tier 1: returns error instead of nil. Tier 2 will
+// implement via the same atomic-replace pattern as templates, scoped to
+// modules/<id>/.
 func applyModuleUpdate(downloadPath, moduleID, modulesDir string) error {
-	// This is a placeholder implementation
-	// In a real implementation, this would:
-	// 1. Extract the downloaded archive to a temporary location
-	// 2. Validate the module structure
-	// 3. Backup existing module
-	// 4. Copy new module to the modules directory
-
-	fmt.Printf("Module update for '%s' not implemented in this version.\n", moduleID)
-	return nil
+	return fmt.Errorf(applyNotImplementedHint+" (component=module.%s, target=%q)", downloadPath, moduleID, modulesDir)
 }

--- a/src/cmd/update_apply.go
+++ b/src/cmd/update_apply.go
@@ -261,7 +261,17 @@ func init() {
 // when an update-apply path is unimplemented in this release. Centralized
 // so the message is consistent across the four stubs and easy to update
 // once Tier 2 (#174) lands real implementations.
-const applyNotImplementedHint = "on-disk update apply not implemented in this version; download bundle to %q and extract manually, or wait for v0.10.0 #174 Tier 2"
+// applyNotImplementedHint is what operators see when an update-apply
+// path is unimplemented in this release. The path interpolated is the
+// already-downloaded bundle: applyXxxUpdate is only reached AFTER
+// DownloadWithProgress has succeeded, so the bundle is sitting on disk
+// at downloadPath. Operators can extract it manually until Tier 2 ships.
+//
+// Side effect (relied upon): os.Exit(1) at the loop tail skips the
+// defer os.RemoveAll(tempDir), which is desirable on this error path —
+// preserving the bundle is exactly what the message directs operators
+// toward. (Tier 2 will add explicit cleanup once apply is real.)
+const applyNotImplementedHint = "on-disk update apply not implemented in this version; bundle downloaded to %q — extract manually, or wait for v0.10.0 #174 Tier 2"
 
 // createBackup creates a backup of the current installation.
 //

--- a/src/cmd/update_apply_test.go
+++ b/src/cmd/update_apply_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/config"
+)
+
+// v0.10.0 #174 Tier 1: every "not implemented" stub in update_apply.go
+// must return a non-nil error so the calling Run loop suppresses the
+// "Successfully updated" message and the CLI exits non-zero.
+//
+// These tests are the contract: if a future change reverts a stub to
+// `return nil`, this test catches it and the v0.10.0 honesty invariant
+// is upheld.
+
+func TestCreateBackup_ReturnsError(t *testing.T) {
+	err := createBackup(&config.Config{})
+	if err == nil {
+		t.Fatal("createBackup returned nil; v0.10.0 #174 Tier 1 requires non-nil error from unimplemented stubs")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should mention 'not implemented'; got %q", err.Error())
+	}
+}
+
+func TestApplyCoreBinaryUpdate_ReturnsError(t *testing.T) {
+	err := applyCoreBinaryUpdate("/tmp/some-download.zip")
+	if err == nil {
+		t.Fatal("applyCoreBinaryUpdate returned nil; v0.10.0 #174 Tier 1 requires non-nil error")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should mention 'not implemented'; got %q", err.Error())
+	}
+	// The error message embeds the download path so operators can
+	// recover by extracting it manually.
+	if !strings.Contains(err.Error(), "/tmp/some-download.zip") {
+		t.Errorf("error should include the download path so operators can recover; got %q", err.Error())
+	}
+}
+
+func TestApplyTemplatesUpdate_ReturnsError(t *testing.T) {
+	err := applyTemplatesUpdate("/tmp/templates.zip", "/usr/local/share/llmrecon/templates")
+	if err == nil {
+		t.Fatal("applyTemplatesUpdate returned nil; v0.10.0 #174 Tier 1 requires non-nil error")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should mention 'not implemented'; got %q", err.Error())
+	}
+	// Both paths should appear in the error so operators can recover.
+	if !strings.Contains(err.Error(), "/tmp/templates.zip") {
+		t.Errorf("error should include the download path; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "/usr/local/share/llmrecon/templates") {
+		t.Errorf("error should include the templates dir; got %q", err.Error())
+	}
+}
+
+func TestApplyModuleUpdate_ReturnsError(t *testing.T) {
+	err := applyModuleUpdate("/tmp/mod.zip", "best-of-n", "/usr/local/share/llmrecon/modules")
+	if err == nil {
+		t.Fatal("applyModuleUpdate returned nil; v0.10.0 #174 Tier 1 requires non-nil error")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should mention 'not implemented'; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "best-of-n") {
+		t.Errorf("error should include the module ID; got %q", err.Error())
+	}
+}
+
+// TestApplyStubsAreConsistent — meta-test asserting all four stubs
+// follow the same pattern: error returned, "not implemented" mentioned.
+// Catches regressions where one stub gets fixed but the others drift.
+func TestApplyStubsAreConsistent(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"createBackup", func() error { return createBackup(&config.Config{}) }},
+		{"applyCoreBinaryUpdate", func() error { return applyCoreBinaryUpdate("x") }},
+		{"applyTemplatesUpdate", func() error { return applyTemplatesUpdate("x", "y") }},
+		{"applyModuleUpdate", func() error { return applyModuleUpdate("x", "y", "z") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.fn(); err == nil {
+				t.Errorf("%s returned nil; expected non-nil per v0.10.0 #174 Tier 1 honesty invariant", c.name)
+			}
+		})
+	}
+}

--- a/src/cmd/update_apply_test.go
+++ b/src/cmd/update_apply_test.go
@@ -65,8 +65,14 @@ func TestApplyModuleUpdate_ReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "not implemented") {
 		t.Errorf("error should mention 'not implemented'; got %q", err.Error())
 	}
+	// Both the module ID and the modules dir should appear in the
+	// error so operators can recover the right file in the right
+	// location. Parity with TestApplyTemplatesUpdate_ReturnsError.
 	if !strings.Contains(err.Error(), "best-of-n") {
 		t.Errorf("error should include the module ID; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "/usr/local/share/llmrecon/modules") {
+		t.Errorf("error should include the modules dir; got %q", err.Error())
 	}
 }
 

--- a/src/update/notification.go
+++ b/src/update/notification.go
@@ -151,12 +151,14 @@ func NewWebhookNotificationHandler(url string, headers map[string]string) *Webho
 	}
 }
 
-// HandleNotification handles a notification by sending it to a webhook
+// HandleNotification handles a notification by sending it to a webhook.
+//
+// v0.10.0 #174 Tier 1: returns a non-nil error rather than silently
+// swallowing the notification. Operators who configured a webhook URL
+// expect deliveries; a no-op return masquerading as success means
+// missed alerts they'll only notice when an incident reveals the gap.
 func (h *WebhookNotificationHandler) HandleNotification(notification *Notification) error {
-	// In a real implementation, this would send an HTTP request to the webhook URL
-	// For now, we'll just log that webhook notification is not implemented
-	fmt.Printf("Webhook notification not implemented (URL: %s)\n", h.URL)
-	return nil
+	return fmt.Errorf("WebhookNotificationHandler.HandleNotification: not implemented in this version (URL=%q); webhook delivery is deferred to v0.11.0", h.URL)
 }
 
 // NotificationManager manages notification handlers

--- a/src/update/verification.go
+++ b/src/update/verification.go
@@ -59,11 +59,19 @@ func (v *IntegrityVerifier) VerifyPackage(pkg *UpdatePackage) (*VerificationResu
 
 	// For now, we'll skip checksum verification
 
-	// Verify digital signature if provided
+	// Verify digital signature if provided.
+	//
+	// v0.10.0 #174 Tier 1: refuse rather than silently log+pass when a
+	// signature is present but the verifier is unimplemented. Operators
+	// who packaged a signed bundle expect verification to either succeed
+	// or fail visibly — silently bypassing means a tampered bundle could
+	// pass through this code path with `Success: true`.
 	if pkg.Manifest.Signature != "" {
-		// This would typically involve public key cryptography
-		// For now, we'll just log that signature verification is not implemented
-		fmt.Fprintf(v.Logger, "Digital signature verification not implemented\n")
+		fmt.Fprintf(v.Logger, "Digital signature verification not implemented; refusing to claim verification success on a signed bundle\n")
+		return &VerificationResult{
+			Success: false,
+			Message: "Digital signature verification not implemented in this version (deferred to v0.11.0); refuse-on-signed-bundle is the v0.10.0 #174 Tier 1 fail-safe",
+		}, fmt.Errorf("digital signature verification not implemented; cannot verify signed bundle")
 	}
 
 	// Log verification success


### PR DESCRIPTION
**Closes the worst class of bug for an air-gapped security tool.** Before this PR, `llmrecon update apply` printed `"Successfully updated to version X"` while writing nothing to disk — leaving operators believing they'd patched a vulnerability when they hadn't.

This is the v0.10.0 plan's honesty release in concrete form:

> *No code path returns "not implemented" while printing or returning success.*

Closes #174 (Tier 1 only; Tier 2 and Tier 3 land in separate PRs).

## What ships

### `src/cmd/update_apply.go`

Four stubs replaced:

| Function | Before | After |
|---|---|---|
| `applyCoreBinaryUpdate` | print + `return nil` | non-nil error including download path |
| `applyTemplatesUpdate` | print + `return nil` | non-nil error including download path + target dir |
| `applyModuleUpdate` | print + `return nil` | non-nil error including module ID + dirs |
| `createBackup` | print + `return nil` | non-nil error |

The `Run` loop now tracks `applyErrorCount` and exits non-zero when any update failed to land:

```
Update process completed with N error(s); see above. No on-disk
changes were made for the failing components.
```

### `src/update/verification.go`

The signed-bundle path previously logged `"Digital signature verification not implemented"` and returned `Success: true`. Now returns `Success: false` + non-nil error, refusing to claim verification on a signed bundle. **A tampered signed bundle would have passed through silently before.**

### `src/update/notification.go`

`WebhookNotificationHandler.HandleNotification` previously printed and returned nil. Now returns an error so missed webhook deliveries are visible to the caller. Alerts the operator configured to receive won't be silently dropped.

## Tests (5 new)

- `TestCreateBackup_ReturnsError`
- `TestApplyCoreBinaryUpdate_ReturnsError` — also asserts download path is in error so operators can recover manually
- `TestApplyTemplatesUpdate_ReturnsError` — both download path + target dir
- `TestApplyModuleUpdate_ReturnsError` — module ID
- `TestApplyStubsAreConsistent` — meta-test: all four stubs follow the same pattern; catches drift if one is fixed for real but the others lag

## What's NOT in this PR

- **Tier 2** (real implementation via ZIP/TAR extract + atomic replace) — separate ~5-day PR per the v0.10.0 plan
- **Tier 3** (binary self-replace + signature verification) — deferred to v0.11.0

This PR is the half-day honesty fix that stops the lying *immediately* while the real implementation proceeds in parallel.

## Plan compliance

Acceptance criteria from `docs/plans/2026-05-02-feat-v0-10-0-phased-execution-plan.md`:

- [x] All "not implemented" stubs in `src/update/` and `src/cmd/update_apply.go` return non-nil errors
- [x] CLI exits non-zero when any stub fires (via `applyErrorCount` tracking)
- [x] `update apply` refuses to apply when verification is unimplemented (`verification.go` returns `Success=false` on signed bundles)

**Honesty invariant preserved**: no code path now returns "not implemented" while printing or returning success.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Update apply failures are now properly tracked and reported with correct exit codes instead of appearing to complete successfully.
  * Unimplemented features (webhook notifications, signature verification, backup, and component apply operations) now return errors instead of silently succeeding.
  * Signature verification now properly fails for signed packages when verification is unavailable, preventing false claims of successful integrity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->