### PR TITLE
feat(attacks): #176 capability gates for agentic/audio modules

### DIFF
--- a/src/attacks/agentic/browser/document_injection.go
+++ b/src/attacks/agentic/browser/document_injection.go
@@ -51,6 +51,15 @@ func (m *DocumentInjectionModule) Execute(ctx context.Context, provider common.P
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasBrowser := provider.(common.BrowserProvider)
+	if !hasBrowser && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.BrowserProvider"), nil
+	}
+	if !hasBrowser {
+		defer common.MarkTextSimulation(result, "browser")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/browser/hidden_instruction.go
+++ b/src/attacks/agentic/browser/hidden_instruction.go
@@ -74,6 +74,15 @@ func (m *HiddenInstructionModule) Execute(ctx context.Context, provider common.P
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasBrowser := provider.(common.BrowserProvider)
+	if !hasBrowser && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.BrowserProvider"), nil
+	}
+	if !hasBrowser {
+		defer common.MarkTextSimulation(result, "browser")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/browser/screenshot_injection.go
+++ b/src/attacks/agentic/browser/screenshot_injection.go
@@ -51,6 +51,15 @@ func (m *ScreenshotInjectionModule) Execute(ctx context.Context, provider common
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasBrowser := provider.(common.BrowserProvider)
+	if !hasBrowser && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.BrowserProvider"), nil
+	}
+	if !hasBrowser {
+		defer common.MarkTextSimulation(result, "browser")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/mcp/filesystem_escape.go
+++ b/src/attacks/agentic/mcp/filesystem_escape.go
@@ -71,6 +71,15 @@ func (m *FilesystemEscapeModule) Execute(ctx context.Context, provider common.Pr
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasMCP := provider.(common.MCPProvider)
+	if !hasMCP && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+	}
+	if !hasMCP {
+		defer common.MarkTextSimulation(result, "mcp")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/mcp/mcp_supply_chain.go
+++ b/src/attacks/agentic/mcp/mcp_supply_chain.go
@@ -59,6 +59,15 @@ func (m *MCPSupplyChainModule) Execute(ctx context.Context, provider common.Prov
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasMCP := provider.(common.MCPProvider)
+	if !hasMCP && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+	}
+	if !hasMCP {
+		defer common.MarkTextSimulation(result, "mcp")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/mcp/sampling_injection.go
+++ b/src/attacks/agentic/mcp/sampling_injection.go
@@ -50,6 +50,15 @@ func (m *SamplingInjectionModule) Execute(ctx context.Context, provider common.P
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasMCP := provider.(common.MCPProvider)
+	if !hasMCP && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+	}
+	if !hasMCP {
+		defer common.MarkTextSimulation(result, "mcp")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/mcp/tool_poisoning.go
+++ b/src/attacks/agentic/mcp/tool_poisoning.go
@@ -66,6 +66,15 @@ func (m *ToolPoisoningModule) Execute(ctx context.Context, provider common.Provi
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasMCP := provider.(common.MCPProvider)
+	if !hasMCP && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+	}
+	if !hasMCP {
+		defer common.MarkTextSimulation(result, "mcp")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/tool_use/agent_exploitation.go
+++ b/src/attacks/agentic/tool_use/agent_exploitation.go
@@ -62,6 +62,16 @@ func (m *AgentExploitationModule) Execute(ctx context.Context, provider common.P
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate. AIShellJack exploits coding-agent
+	// tool surfaces — fits MCPProvider.
+	_, hasMCP := provider.(common.MCPProvider)
+	if !hasMCP && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+	}
+	if !hasMCP {
+		defer common.MarkTextSimulation(result, "mcp")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/agentic/tool_use/imist.go
+++ b/src/attacks/agentic/tool_use/imist.go
@@ -65,6 +65,16 @@ func (m *IMISTModule) Execute(ctx context.Context, provider common.Provider, con
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate. iMIST exploits function-calling /
+	// tool-invocation interfaces — fits MCPProvider.
+	_, hasMCP := provider.(common.MCPProvider)
+	if !hasMCP && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+	}
+	if !hasMCP {
+		defer common.MarkTextSimulation(result, "mcp")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/audio/audio_jailbreak.go
+++ b/src/attacks/audio/audio_jailbreak.go
@@ -66,6 +66,15 @@ func (m *AudioJailbreakModule) Execute(ctx context.Context, provider common.Prov
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasAudio := provider.(common.AudioProvider)
+	if !hasAudio && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.AudioProvider"), nil
+	}
+	if !hasAudio {
+		defer common.MarkTextSimulation(result, "audio")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/audio/bon_audio.go
+++ b/src/attacks/audio/bon_audio.go
@@ -66,6 +66,15 @@ func (m *BoNAudioModule) Execute(ctx context.Context, provider common.Provider, 
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasAudio := provider.(common.AudioProvider)
+	if !hasAudio && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.AudioProvider"), nil
+	}
+	if !hasAudio {
+		defer common.MarkTextSimulation(result, "audio")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/audio/multilingual_audio.go
+++ b/src/attacks/audio/multilingual_audio.go
@@ -73,6 +73,15 @@ func (m *MultilingualAudioModule) Execute(ctx context.Context, provider common.P
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasAudio := provider.(common.AudioProvider)
+	if !hasAudio && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.AudioProvider"), nil
+	}
+	if !hasAudio {
+		defer common.MarkTextSimulation(result, "audio")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/audio/speech_model_exploit.go
+++ b/src/attacks/audio/speech_model_exploit.go
@@ -64,6 +64,15 @@ func (m *SpeechModelExploitModule) Execute(ctx context.Context, provider common.
 		Metadata:  make(map[string]interface{}),
 	}
 
+	// v0.10.0 #176 capability gate.
+	_, hasAudio := provider.(common.AudioProvider)
+	if !hasAudio && !common.TextSimulationOptIn(config) {
+		return common.MissingCapabilitySkip(m.Name(), "common.AudioProvider"), nil
+	}
+	if !hasAudio {
+		defer common.MarkTextSimulation(result, "audio")
+	}
+
 	objective := config.Objective
 	if objective == "" {
 		objective = config.Payload

--- a/src/attacks/common/capabilities.go
+++ b/src/attacks/common/capabilities.go
@@ -122,6 +122,168 @@ type Cleaner interface {
 	Cleanup(ctx context.Context, recordIDs []string) error
 }
 
+// ---------------------------------------------------------------------------
+// v0.10.0 #176 — modality-specific capabilities for agentic + audio attacks
+// ---------------------------------------------------------------------------
+//
+// Pre-v0.10.0, these attack modules called provider.Query with text
+// payloads pretending to be MCP-tool / browser / audio modality
+// invocations. Compliance reporting and bandit reward couldn't tell
+// "ran fully against the right surface" from "ran in text simulation
+// against a non-matching provider."
+//
+// These interfaces are the v0.10.0 #176 fix. Modules type-assert at
+// Execute() entry; emit SkipMissingCapability when absent. Operators
+// who explicitly want the legacy text-simulation behavior pass
+// Metadata["mode"]="text_simulation" — modules then fall back to
+// plain Query AND set Metadata["true_modality"] on the result so
+// downstream consumers can filter simulations out.
+//
+// No provider in v0.10.0 implements these yet — that's #166's adapter
+// work. Until then, real-provider runs of these modules emit clean
+// Skipped outcomes by default, which is the correct behavior.
+
+// MCPProvider is implemented by providers that can invoke Model
+// Context Protocol tools natively. Used by attacks targeting
+// MCP infrastructure (mcp/* and tool_use/* modules).
+type MCPProvider interface {
+	Provider
+	// InvokeTool calls a named MCP tool with the given arguments.
+	// Returns the tool's text response, or an error if the call
+	// failed at the protocol/transport layer.
+	InvokeTool(ctx context.Context, toolName string, args map[string]interface{}) (string, error)
+}
+
+// BrowserProvider is implemented by providers that can fetch and
+// reason over web content (used by AI browser-agent attacks).
+// agentic/browser/* modules require this capability.
+type BrowserProvider interface {
+	Provider
+	// BrowseAndQuery fetches the URL, then asks the model the prompt
+	// in the context of the fetched content. Returns the model's
+	// response text.
+	BrowseAndQuery(ctx context.Context, url string, prompt string) (string, error)
+}
+
+// AudioProvider is implemented by providers that accept audio inputs
+// alongside text prompts (e.g., GPT-4o audio, Gemini with audio,
+// speech-language models). audio/* modules require this capability.
+type AudioProvider interface {
+	Provider
+	// QueryWithAudio sends a prompt with an audio attachment and
+	// returns the model's text response.
+	QueryWithAudio(ctx context.Context, prompt string, audio AudioPayload) (string, error)
+}
+
+// AudioPayload carries audio bytes + format metadata. Constructor
+// validates the format enum and a basic non-empty-bytes check; rich
+// audio-specific validation (sample rate, codec) is deferred to the
+// adapter implementing AudioProvider.
+type AudioPayload struct {
+	bytes  []byte
+	format AudioFormat
+}
+
+// AudioFormat enumerates the supported audio container formats.
+type AudioFormat string
+
+const (
+	AudioFormatWAV  AudioFormat = "wav"
+	AudioFormatMP3  AudioFormat = "mp3"
+	AudioFormatOGG  AudioFormat = "ogg"
+	AudioFormatFLAC AudioFormat = "flac"
+)
+
+// MaxAudioPayloadBytes caps the in-memory size of an audio payload.
+// Mirrors MaxImagePayloadBytes — providers that accept larger should
+// upload out-of-band.
+const MaxAudioPayloadBytes = 25 * 1024 * 1024 // 25 MiB
+
+// NewAudioPayload constructs an AudioPayload after validating the
+// format enum and non-empty bytes.
+func NewAudioPayload(b []byte, format AudioFormat) (AudioPayload, error) {
+	if len(b) == 0 {
+		return AudioPayload{}, fmt.Errorf("audio payload: empty bytes")
+	}
+	if len(b) > MaxAudioPayloadBytes {
+		return AudioPayload{}, fmt.Errorf("audio payload: %d bytes exceeds max %d", len(b), MaxAudioPayloadBytes)
+	}
+	if !validAudioFormat(format) {
+		return AudioPayload{}, fmt.Errorf("audio payload: unsupported format %q", format)
+	}
+	owned := make([]byte, len(b))
+	copy(owned, b)
+	return AudioPayload{bytes: owned, format: format}, nil
+}
+
+// Bytes returns a defensive copy of the audio bytes.
+func (p AudioPayload) Bytes() []byte {
+	if p.bytes == nil {
+		return nil
+	}
+	out := make([]byte, len(p.bytes))
+	copy(out, p.bytes)
+	return out
+}
+
+// Format returns the audio format.
+func (p AudioPayload) Format() AudioFormat { return p.format }
+
+func validAudioFormat(f AudioFormat) bool {
+	switch f {
+	case AudioFormatWAV, AudioFormatMP3, AudioFormatOGG, AudioFormatFLAC:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// v0.10.0 #176 — capability-gate helpers
+// ---------------------------------------------------------------------------
+//
+// Modules use these at Execute() entry to keep the gate boilerplate
+// to ~3 lines:
+//
+//   _, hasMCP := provider.(common.MCPProvider)
+//   if !hasMCP && !common.TextSimulationOptIn(config) {
+//       return common.MissingCapabilitySkip(m.Name(), "common.MCPProvider"), nil
+//   }
+//   // ... existing module logic ...
+//   if !hasMCP {
+//       common.MarkTextSimulation(result, "mcp")
+//   }
+
+// TextSimulationOptIn reports whether the operator passed
+// Metadata["mode"]="text_simulation" — the documented escape hatch
+// for running modality-specific modules against text-only providers
+// as a best-effort approximation of the true modality. Without the
+// opt-in, modules emit OutcomeSkipped + SkipMissingCapability.
+func TextSimulationOptIn(config AttackConfig) bool {
+	return config.Metadata["mode"] == "text_simulation"
+}
+
+// MissingCapabilitySkip returns an OutcomeSkipped result citing the
+// named capability interface. Use at Execute() entry when both
+// the type assertion fails and the operator hasn't opted into
+// text simulation.
+func MissingCapabilitySkip(moduleName, capabilityName string) *AttackResult {
+	r := NewAttackResult(moduleName, OutcomeSkipped)
+	r.WithSkip(SkipMissingCapability, capabilityName)
+	return r
+}
+
+// MarkTextSimulation tags the result so downstream consumers
+// (compliance scorecards, bandit reward) can filter simulated runs
+// out of aggregations. Sets Metadata["mode"]="text_simulation" and
+// Metadata["true_modality"]=<modality string>.
+func MarkTextSimulation(result *AttackResult, trueModality string) {
+	if result.Metadata == nil {
+		result.Metadata = map[string]interface{}{}
+	}
+	result.Metadata["mode"] = "text_simulation"
+	result.Metadata["true_modality"] = trueModality
+}
+
 // --- ImagePayload and supporting typed enums ---
 
 // ImageMimeType enumerates the image MIME types supported by ImageProvider

--- a/src/attacks/common/capabilities_test.go
+++ b/src/attacks/common/capabilities_test.go
@@ -124,6 +124,71 @@ func TestNewImagePayloadURL(t *testing.T) {
 	}
 }
 
+// TestNewAudioPayload covers the AudioPayload constructor's
+// validation contract. Mirrors the existing TestNewImagePayloadBytes.
+func TestNewAudioPayload(t *testing.T) {
+	smallWAV := []byte{0x52, 0x49, 0x46, 0x46} // "RIFF"
+	tooBig := make([]byte, MaxAudioPayloadBytes+1)
+
+	cases := []struct {
+		name    string
+		b       []byte
+		format  AudioFormat
+		wantErr string
+	}{
+		{"valid wav", smallWAV, AudioFormatWAV, ""},
+		{"valid mp3", smallWAV, AudioFormatMP3, ""},
+		{"valid ogg", smallWAV, AudioFormatOGG, ""},
+		{"valid flac", smallWAV, AudioFormatFLAC, ""},
+		{"empty bytes", []byte{}, AudioFormatWAV, "empty bytes"},
+		{"oversized", tooBig, AudioFormatWAV, "exceeds max"},
+		{"bogus format", smallWAV, AudioFormat("opus"), "unsupported format"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, err := NewAudioPayload(c.b, c.format)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if string(p.Bytes()) != string(c.b) {
+					t.Errorf("Bytes() round-trip mismatch")
+				}
+				if p.Format() != c.format {
+					t.Errorf("Format() = %q, want %q", p.Format(), c.format)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestAudioPayloadDefensiveCopy mirrors the same contract as
+// TestImagePayloadDefensiveCopy: caller mutations don't affect the
+// payload's internal state.
+func TestAudioPayloadDefensiveCopy(t *testing.T) {
+	original := []byte{0x52, 0x49, 0x46, 0x46, 0x01}
+	p, err := NewAudioPayload(original, AudioFormatWAV)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original[0] = 0xFF
+	if p.Bytes()[0] == 0xFF {
+		t.Errorf("constructor did not copy; caller mutation visible inside payload")
+	}
+	first := p.Bytes()
+	first[0] = 0xFF
+	if p.Bytes()[0] == 0xFF {
+		t.Errorf("Bytes() did not copy; mutation across reads")
+	}
+}
+
 // fakeProvider implements common.Provider with no-op methods. Used below to
 // confirm that adding the optional capability methods produces a value
 // satisfying the corresponding interface.
@@ -155,6 +220,24 @@ type fakeReasoningProvider struct{ fakeProvider }
 
 func (fakeReasoningProvider) QueryWithReasoning(_ context.Context, _ []Message, _ map[string]interface{}) (string, ReasoningTrace, error) {
 	return "ok", ReasoningTrace{Steps: []string{"step 1", "step 2"}}, nil
+}
+
+type fakeMCPProvider struct{ fakeProvider }
+
+func (fakeMCPProvider) InvokeTool(_ context.Context, _ string, _ map[string]interface{}) (string, error) {
+	return "tool result", nil
+}
+
+type fakeBrowserProvider struct{ fakeProvider }
+
+func (fakeBrowserProvider) BrowseAndQuery(_ context.Context, _, _ string) (string, error) {
+	return "browser result", nil
+}
+
+type fakeAudioProvider struct{ fakeProvider }
+
+func (fakeAudioProvider) QueryWithAudio(_ context.Context, _ string, _ AudioPayload) (string, error) {
+	return "audio result", nil
 }
 
 type fakeCleaner struct{}
@@ -190,6 +273,26 @@ func TestCapabilitiesAreSatisfiableByConcreteTypes(t *testing.T) {
 	}
 	if trace.Signed {
 		t.Errorf("default ReasoningTrace.Signed should be false")
+	}
+
+	// v0.10.0 #176 capabilities
+	var mcp MCPProvider = fakeMCPProvider{}
+	if r, _ := mcp.InvokeTool(context.Background(), "x", nil); r != "tool result" {
+		t.Errorf("MCPProvider.InvokeTool() = %q, want \"tool result\"", r)
+	}
+
+	var bp BrowserProvider = fakeBrowserProvider{}
+	if r, _ := bp.BrowseAndQuery(context.Background(), "https://example.com", "x"); r != "browser result" {
+		t.Errorf("BrowserProvider.BrowseAndQuery() = %q, want \"browser result\"", r)
+	}
+
+	var ap AudioProvider = fakeAudioProvider{}
+	audio, err := NewAudioPayload([]byte{0x52, 0x49, 0x46, 0x46}, AudioFormatWAV) // RIFF header bytes
+	if err != nil {
+		t.Errorf("NewAudioPayload: %v", err)
+	}
+	if r, _ := ap.QueryWithAudio(context.Background(), "x", audio); r != "audio result" {
+		t.Errorf("AudioProvider.QueryWithAudio() = %q, want \"audio result\"", r)
 	}
 
 	var c Cleaner = fakeCleaner{}

--- a/src/attacks/integration/capability_gates_test.go
+++ b/src/attacks/integration/capability_gates_test.go
@@ -1,0 +1,169 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/attacks"
+	"github.com/perplext/LLMrecon/src/attacks/common"
+)
+
+// v0.10.0 #176 capability-gate contract tests.
+//
+// Asserts every module that registered as needing a modality-specific
+// capability emits the right outcome against a plain-text-only provider:
+//
+//   - default behavior: OutcomeSkipped + SkipMissingCapability,
+//     citing the right capability interface
+//   - operator opt-in via Metadata["mode"]="text_simulation":
+//     module runs end-to-end and tags result with Metadata["mode"]
+//     and Metadata["true_modality"]
+//
+// These tests are the v0.10.0 honesty invariant for the agentic + audio
+// surface: no module should silently text-simulate by default.
+
+// gateTestCase pairs a registered module name with the capability
+// interface it should gate on and the modality string the
+// MarkTextSimulation tag uses.
+type gateTestCase struct {
+	moduleName       string
+	capabilityName   string // expected SkipDetail substring
+	trueModality     string // expected Metadata["true_modality"] under text_simulation opt-in
+	objective        string // operator-supplied objective so module doesn't bail on missing payload
+}
+
+// gateCases lists every module covered by v0.10.0 #176 — 4 mcp +
+// 2 tool_use + 3 browser + 4 audio = 13 modules.
+var gateCases = []gateTestCase{
+	// MCP modules
+	{"mcp_tool_poisoning", "common.MCPProvider", "mcp", "exfiltrate user data"},
+	{"mcp_sampling_injection", "common.MCPProvider", "mcp", "exfiltrate user data"},
+	{"mcp_supply_chain", "common.MCPProvider", "mcp", "install backdoor"},
+	{"mcp_filesystem_escape", "common.MCPProvider", "mcp", "read /etc/passwd"},
+
+	// tool_use modules (also MCPProvider — function-calling is MCP-shaped)
+	{"imist", "common.MCPProvider", "mcp", "obtain restricted info"},
+	{"agent_exploitation", "common.MCPProvider", "mcp", "execute unauthorized command"},
+
+	// Browser modules
+	{"browser_document_injection", "common.BrowserProvider", "browser", "read shared doc"},
+	{"browser_hidden_instruction", "common.BrowserProvider", "browser", "follow hidden link"},
+	{"browser_screenshot_injection", "common.BrowserProvider", "browser", "click invisible button"},
+
+	// Audio modules
+	{"audio_jailbreak", "common.AudioProvider", "audio", "bypass safety"},
+	{"bon_audio", "common.AudioProvider", "audio", "produce harmful output"},
+	{"multilingual_audio", "common.AudioProvider", "audio", "bypass via translation"},
+	{"speech_model_exploit", "common.AudioProvider", "audio", "exploit ASR pipeline"},
+}
+
+// plainTextProvider implements common.Provider only — no modality-
+// specific capability. Modules under test should either Skip against
+// this OR fall back to text simulation when opted in.
+type plainTextProvider struct{}
+
+func (plainTextProvider) Query(_ context.Context, _ []common.Message, _ map[string]interface{}) (string, error) {
+	return "I cannot help with that.", nil
+}
+func (plainTextProvider) GetName() string             { return "plain-text" }
+func (plainTextProvider) GetModel() string            { return "test-model" }
+func (plainTextProvider) GetTokenCount(s string) int  { return len(s) / 4 }
+
+// TestCapabilityGate_DefaultSkipsAgainstPlainTextProvider asserts
+// every gated module emits the expected SkipMissingCapability when
+// run against a plain-text provider WITHOUT the simulation opt-in.
+//
+// This is the central honesty invariant: by default, a module that
+// claims a modality should Skip rather than silently text-simulate.
+func TestCapabilityGate_DefaultSkipsAgainstPlainTextProvider(t *testing.T) {
+	provider := plainTextProvider{}
+	for _, tc := range gateCases {
+		t.Run(tc.moduleName, func(t *testing.T) {
+			module, err := attacks.DefaultRegistry.Get(tc.moduleName)
+			if err != nil {
+				t.Fatalf("module %q not registered: %v", tc.moduleName, err)
+			}
+			cfg := common.AttackConfig{
+				Payload:   tc.objective,
+				Objective: tc.objective,
+			}
+			result, err := module.Execute(context.Background(), provider, cfg)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("Execute returned nil result")
+			}
+			if result.Outcome != common.OutcomeSkipped {
+				t.Errorf("Outcome = %q, want Skipped (module silently text-simulated against plain-text provider — v0.10.0 #176 honesty invariant violated)",
+					result.Outcome)
+			}
+			if result.SkipReason != common.SkipMissingCapability {
+				t.Errorf("SkipReason = %q, want %q", result.SkipReason, common.SkipMissingCapability)
+			}
+			if got := result.SkipDetail; got != tc.capabilityName {
+				t.Errorf("SkipDetail = %q, want %q", got, tc.capabilityName)
+			}
+		})
+	}
+}
+
+// TestCapabilityGate_TextSimulationOptInTagsResult asserts that when
+// the operator passes Metadata["mode"]="text_simulation", the module
+// runs end-to-end against the plain-text provider AND the result is
+// tagged with Metadata["mode"]="text_simulation" + the right
+// true_modality string.
+//
+// Downstream consumers (compliance scorecards, bandit reward) filter
+// on these metadata keys to exclude simulated runs from real-attack
+// aggregations.
+func TestCapabilityGate_TextSimulationOptInTagsResult(t *testing.T) {
+	provider := plainTextProvider{}
+	for _, tc := range gateCases {
+		t.Run(tc.moduleName, func(t *testing.T) {
+			module, err := attacks.DefaultRegistry.Get(tc.moduleName)
+			if err != nil {
+				t.Fatalf("module %q not registered: %v", tc.moduleName, err)
+			}
+			cfg := common.AttackConfig{
+				Payload:   tc.objective,
+				Objective: tc.objective,
+				Metadata:  map[string]string{"mode": "text_simulation"},
+			}
+			result, err := module.Execute(context.Background(), provider, cfg)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("Execute returned nil result")
+			}
+			// Should NOT be Skipped — the operator opted into
+			// simulation, so the module ran fully.
+			if result.Outcome == common.OutcomeSkipped && result.SkipReason == common.SkipMissingCapability {
+				t.Errorf("Outcome=Skipped/SkipMissingCapability under text_simulation opt-in — module ignored the opt-in")
+			}
+			// Result must be tagged.
+			if result.Metadata == nil {
+				t.Fatal("result.Metadata is nil; expected text_simulation tags")
+			}
+			if got := result.Metadata["mode"]; got != "text_simulation" {
+				t.Errorf("Metadata[\"mode\"] = %v, want \"text_simulation\"", got)
+			}
+			if got := result.Metadata["true_modality"]; got != tc.trueModality {
+				t.Errorf("Metadata[\"true_modality\"] = %v, want %q", got, tc.trueModality)
+			}
+		})
+	}
+}
+
+// TestCapabilityGate_AllModulesRegistered ensures every module the
+// gate cases reference actually exists in the registry. Catches typos
+// in moduleName fields up front, before the per-module test loops
+// run.
+func TestCapabilityGate_AllModulesRegistered(t *testing.T) {
+	for _, tc := range gateCases {
+		if _, err := attacks.DefaultRegistry.Get(tc.moduleName); err != nil {
+			t.Errorf("module %q in gateCases is not registered: %v", tc.moduleName, err)
+		}
+	}
+}

--- a/src/attacks/integration/doc.go
+++ b/src/attacks/integration/doc.go
@@ -11,6 +11,10 @@ package integration
 
 import (
 	_ "github.com/perplext/LLMrecon/src/attacks/adaptive"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/browser"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/mcp"
+	_ "github.com/perplext/LLMrecon/src/attacks/agentic/tool_use"
+	_ "github.com/perplext/LLMrecon/src/attacks/audio"
 	_ "github.com/perplext/LLMrecon/src/attacks/memory"
 	_ "github.com/perplext/LLMrecon/src/attacks/multimodal"
 	_ "github.com/perplext/LLMrecon/src/attacks/reasoning"


### PR DESCRIPTION
## Summary

Closes #176. Adds the v0.10.0 honesty invariant for the multi-modal attack surface: 13 modules (4 mcp + 2 tool_use + 3 browser + 4 audio) now skip with `SkipMissingCapability` when the provider doesn't satisfy the corresponding capability interface, instead of silently text-simulating and reporting a misleading outcome.

## Capability interfaces (`src/attacks/common/capabilities.go`)

- `MCPProvider` gates the 6 mcp + tool_use modules (function-calling is MCP-shaped)
- `BrowserProvider` gates the 3 browser modules
- `AudioProvider` + `AudioPayload` gates the 4 audio modules

## Operator opt-in

Passing `AttackConfig.Metadata[\"mode\"]=\"text_simulation\"` bypasses the gate and runs the module end-to-end against any provider, tagging the result with `Metadata[\"mode\"]=\"text_simulation\"` and `Metadata[\"true_modality\"]={\"mcp\",\"browser\",\"audio\"}`. Downstream consumers (compliance scorecards, bandit reward) filter on these keys so simulated runs don't pollute real-attack aggregations.

## Helpers

```go
func TextSimulationOptIn(config AttackConfig) bool
func MissingCapabilitySkip(moduleName, capabilityName string) *AttackResult
func MarkTextSimulation(result *AttackResult, trueModality string)
```

## Standard gate pattern

```go
_, hasMCP := provider.(common.MCPProvider)
if !hasMCP && !common.TextSimulationOptIn(config) {
    return common.MissingCapabilitySkip(m.Name(), \"common.MCPProvider\"), nil
}
if !hasMCP {
    defer common.MarkTextSimulation(result, \"mcp\")
}
```

Replicated across all 13 modules.

## Modules gated

| Package | Module | Capability |
|---|---|---|
| agentic/mcp | tool_poisoning, sampling_injection, mcp_supply_chain, filesystem_escape | MCPProvider |
| agentic/tool_use | imist, agent_exploitation | MCPProvider |
| agentic/browser | document_injection, hidden_instruction, screenshot_injection | BrowserProvider |
| audio | audio_jailbreak, bon_audio, multilingual_audio, speech_model_exploit | AudioProvider |

## Contract tests

`src/attacks/integration/capability_gates_test.go`:

- `TestCapabilityGate_DefaultSkipsAgainstPlainTextProvider` — per-module subtest asserting `OutcomeSkipped` + `SkipMissingCapability` + correct `SkipDetail`
- `TestCapabilityGate_TextSimulationOptInTagsResult` — per-module subtest asserting opt-in produces a non-skipped result tagged with `mode` + `true_modality`
- `TestCapabilityGate_AllModulesRegistered` — catches typos in the `gateCases` table up front

The integration package now blank-imports `browser/mcp/tool_use/audio` so `init()` blocks register the modules; without this the registry was empty inside the integration test binary.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./src/attacks/integration/ -run TestCapabilityGate -count=1 -v\` — 27/27 subtests pass
- [x] \`go test ./... -count=1\` — full suite green
- [x] \`bash scripts/verify-drift.sh\` — drift checks pass