### PR TITLE
feat(provider): #166 (Tier A) OpenAI ImageProvider + ReasoningProvider wiring

### DIFF
--- a/src/provider/bridge/bridge.go
+++ b/src/provider/bridge/bridge.go
@@ -31,21 +31,40 @@ import (
 )
 
 // WrapCore returns a common.Provider backed by the given core.Provider.
-// The returned value also implements common.* capability interfaces
-// where the wrapped provider supports the underlying core capability:
-// future v0.10.0 issue #166 work will extend this.
+// The returned value also implements common.ImageProvider and/or
+// common.ReasoningProvider when the wrapped provider implements the
+// corresponding core capability interface (v0.10.0 #166).
 //
-// Returns the inner provider wrapped in a coreAdapter. Caller retains
-// ownership of the inner provider — the adapter does not call Close()
-// on it; that's the caller's responsibility.
+// The 2x2 capability matrix is realized by four concrete wrapper types
+// (coreAdapter, imageAdapter, reasoningAdapter, imageReasoningAdapter)
+// rather than one struct with always-present methods. The reason: Go's
+// type assertion is structural at compile time — a single struct with
+// QueryWithImages would always satisfy common.ImageProvider, defeating
+// the type-assertion gate that attack modules use to detect capability
+// presence. Modules need OK to mean "this provider really does images,"
+// not "the wrapper has the method."
+//
+// Returns the inner provider wrapped in a coreAdapter (or capability
+// extension thereof). Caller retains ownership of the inner provider —
+// the adapter does not call Close() on it; that's the caller's
+// responsibility.
 func WrapCore(p core.Provider) common.Provider {
 	if p == nil {
-		// Defensive: nil core.Provider would NPE inside Query. Operators
-		// should never see this path; constructor errors should have
-		// already returned, but the contract is clearer with the guard.
 		return nilProvider{}
 	}
-	return &coreAdapter{inner: p}
+	base := &coreAdapter{inner: p}
+	img, hasImg := p.(core.ImageProvider)
+	rsn, hasRsn := p.(core.ReasoningProvider)
+	switch {
+	case hasImg && hasRsn:
+		return &imageReasoningAdapter{coreAdapter: base, img: img, rsn: rsn}
+	case hasImg:
+		return &imageAdapter{coreAdapter: base, img: img}
+	case hasRsn:
+		return &reasoningAdapter{coreAdapter: base, rsn: rsn}
+	default:
+		return base
+	}
 }
 
 // coreAdapter is the WrapCore-returned common.Provider.
@@ -62,18 +81,7 @@ type coreAdapter struct {
 // Modules that need richer control should configure the underlying
 // provider via core.ProviderConfig before WrapCore.
 func (a *coreAdapter) Query(ctx context.Context, msgs []common.Message, opts map[string]interface{}) (string, error) {
-	req := &core.ChatCompletionRequest{
-		Messages: convertMessages(msgs),
-	}
-
-	// Default to the provider's configured model. Operator can override
-	// via opts["model"] if they want to drive multiple models from a
-	// single wrapped provider.
-	if cfg := a.inner.GetConfig(); cfg != nil {
-		req.Model = cfg.DefaultModel
-	}
-	applyOptions(req, opts)
-
+	req := a.buildChatRequest(msgs, opts)
 	resp, err := a.inner.ChatCompletion(ctx, req)
 	if err != nil {
 		return "", err
@@ -116,6 +124,151 @@ func (a *coreAdapter) GetTokenCount(text string) int {
 		return len(text) / 4
 	}
 	return n
+}
+
+// ---------------------------------------------------------------------------
+// Capability-extension wrappers (v0.10.0 #166)
+// ---------------------------------------------------------------------------
+//
+// Each adapter embeds *coreAdapter so all common.Provider methods (Query,
+// GetName, GetModel, GetTokenCount) inherit from the base. The capability
+// methods (QueryWithImages, QueryWithReasoning) live on the extension
+// type. The compile-time interface checks below catch missing methods.
+
+// imageAdapter exposes common.ImageProvider on top of coreAdapter.
+type imageAdapter struct {
+	*coreAdapter
+	img core.ImageProvider
+}
+
+// QueryWithImages translates the common-side prompt + ImagePayload list
+// into a core.ChatCompletionRequest + []core.ImageInput, calls through
+// the wrapped core.ImageProvider, and extracts the first choice's text.
+//
+// Constraint translation:
+//   - common.ImagePayload's mutual-exclusion invariant (bytes XOR url)
+//     was already validated at construction; the conversion here trusts
+//     it but the underlying core.ImageInput documents the same.
+//   - Empty images slice short-circuits to a typed error rather than
+//     falling through to the core.ImageProvider — the bridge's contract
+//     is that QueryWithImages with zero images is a programming error.
+func (a *imageAdapter) QueryWithImages(ctx context.Context, prompt string, images []common.ImagePayload, opts map[string]interface{}) (string, error) {
+	if len(images) == 0 {
+		return "", fmt.Errorf("bridge: QueryWithImages: at least one image required")
+	}
+	req := a.buildChatRequest([]common.Message{{Role: "user", Content: prompt}}, opts)
+	coreImages := make([]core.ImageInput, 0, len(images))
+	for _, p := range images {
+		coreImages = append(coreImages, core.ImageInput{
+			Bytes:    p.Bytes(),
+			URL:      p.URL(),
+			MimeType: string(p.MimeType()),
+			Detail:   string(p.Detail()),
+		})
+	}
+	resp, err := a.img.ChatWithImages(ctx, req, coreImages)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return "", fmt.Errorf("provider %s returned no choices", a.GetName())
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+// reasoningAdapter exposes common.ReasoningProvider on top of coreAdapter.
+type reasoningAdapter struct {
+	*coreAdapter
+	rsn core.ReasoningProvider
+}
+
+// QueryWithReasoning calls through to the wrapped core.ReasoningProvider
+// and translates the heavier core.ThinkingTrace into the minimal
+// common.ReasoningTrace shape attack modules consume.
+//
+// trace.Signed: the bridge defaults to false. Anthropic's adapter sets
+// Signed=true on the core.ThinkingTrace via a sentinel marker (the
+// Anthropic-specific implementation surfaces this via a field on
+// core.ThinkingTrace once #166 lands the Anthropic side); for OpenAI
+// the trace is plain summary text so Signed stays false. See the
+// signedReasoningProvider sentinel below.
+func (a *reasoningAdapter) QueryWithReasoning(ctx context.Context, msgs []common.Message, opts map[string]interface{}) (string, common.ReasoningTrace, error) {
+	req := a.buildChatRequest(msgs, opts)
+	resp, trace, err := a.rsn.ChatWithReasoning(ctx, req)
+	if err != nil {
+		return "", common.ReasoningTrace{}, err
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return "", common.ReasoningTrace{}, fmt.Errorf("provider %s returned no choices", a.GetName())
+	}
+	steps := make([]string, 0)
+	if trace != nil {
+		for _, s := range trace.Steps {
+			if s.Content != "" {
+				steps = append(steps, s.Content)
+			}
+		}
+	}
+	signed := false
+	if sig, ok := a.rsn.(signedReasoningProvider); ok {
+		signed = sig.ReasoningTraceIsSigned()
+	}
+	return resp.Choices[0].Message.Content, common.ReasoningTrace{Steps: steps, Signed: signed}, nil
+}
+
+// signedReasoningProvider is an opt-in marker any core.ReasoningProvider
+// can implement to declare its reasoning trace is cryptographically
+// signed (Anthropic). Modules consuming common.ReasoningTrace.Signed
+// gate mutation paths on the field; without this marker the bridge
+// defaults to Signed=false.
+type signedReasoningProvider interface {
+	ReasoningTraceIsSigned() bool
+}
+
+// imageReasoningAdapter exposes both common.ImageProvider and
+// common.ReasoningProvider. The capability methods come from the two
+// embedded extension types; the embedded *coreAdapter remains the
+// common.Provider implementer.
+type imageReasoningAdapter struct {
+	*coreAdapter
+	img core.ImageProvider
+	rsn core.ReasoningProvider
+}
+
+// QueryWithImages — see imageAdapter.QueryWithImages.
+func (a *imageReasoningAdapter) QueryWithImages(ctx context.Context, prompt string, images []common.ImagePayload, opts map[string]interface{}) (string, error) {
+	tmp := &imageAdapter{coreAdapter: a.coreAdapter, img: a.img}
+	return tmp.QueryWithImages(ctx, prompt, images, opts)
+}
+
+// QueryWithReasoning — see reasoningAdapter.QueryWithReasoning.
+func (a *imageReasoningAdapter) QueryWithReasoning(ctx context.Context, msgs []common.Message, opts map[string]interface{}) (string, common.ReasoningTrace, error) {
+	tmp := &reasoningAdapter{coreAdapter: a.coreAdapter, rsn: a.rsn}
+	return tmp.QueryWithReasoning(ctx, msgs, opts)
+}
+
+// Compile-time interface checks. These fail at build time if the
+// wrappers stop satisfying the common.* contracts.
+var (
+	_ common.Provider          = (*coreAdapter)(nil)
+	_ common.ImageProvider     = (*imageAdapter)(nil)
+	_ common.ReasoningProvider = (*reasoningAdapter)(nil)
+	_ common.ImageProvider     = (*imageReasoningAdapter)(nil)
+	_ common.ReasoningProvider = (*imageReasoningAdapter)(nil)
+)
+
+// buildChatRequest centralizes the common.Message → core.ChatCompletionRequest
+// conversion so the capability adapters share a single source of truth
+// with the plain-text Query path.
+func (a *coreAdapter) buildChatRequest(msgs []common.Message, opts map[string]interface{}) *core.ChatCompletionRequest {
+	req := &core.ChatCompletionRequest{
+		Messages: convertMessages(msgs),
+	}
+	if cfg := a.inner.GetConfig(); cfg != nil {
+		req.Model = cfg.DefaultModel
+	}
+	applyOptions(req, opts)
+	return req
 }
 
 // ---------------------------------------------------------------------------

--- a/src/provider/bridge/bridge_test.go
+++ b/src/provider/bridge/bridge_test.go
@@ -331,6 +331,312 @@ func TestGetModel_FallsBackOnEmptyConfig(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Capability-promotion tests (v0.10.0 #166)
+// ---------------------------------------------------------------------------
+//
+// These assert WrapCore returns the right wrapper type based on the
+// underlying core.Provider's capabilities, and that the capability
+// methods translate request/response shapes correctly.
+
+// imageCapableMock embeds mockCoreProvider and adds ChatWithImages so
+// it satisfies core.ImageProvider.
+type imageCapableMock struct {
+	*mockCoreProvider
+	LastImages []core.ImageInput
+}
+
+func (m *imageCapableMock) ChatWithImages(_ context.Context, req *core.ChatCompletionRequest, images []core.ImageInput) (*core.ChatCompletionResponse, error) {
+	m.LastRequest = req
+	m.LastImages = images
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	if m.Response != nil {
+		return m.Response, nil
+	}
+	return &core.ChatCompletionResponse{
+		Choices: []core.ChatCompletionChoice{{
+			Index:        0,
+			Message:      core.Message{Role: "assistant", Content: "saw an image"},
+			FinishReason: "stop",
+		}},
+	}, nil
+}
+
+// reasoningCapableMock embeds mockCoreProvider and adds ChatWithReasoning
+// so it satisfies core.ReasoningProvider.
+type reasoningCapableMock struct {
+	*mockCoreProvider
+	Trace *core.ThinkingTrace
+}
+
+func (m *reasoningCapableMock) ChatWithReasoning(_ context.Context, req *core.ChatCompletionRequest) (*core.ChatCompletionResponse, *core.ThinkingTrace, error) {
+	m.LastRequest = req
+	if m.Err != nil {
+		return nil, nil, m.Err
+	}
+	resp := m.Response
+	if resp == nil {
+		resp = &core.ChatCompletionResponse{
+			Choices: []core.ChatCompletionChoice{{
+				Index:        0,
+				Message:      core.Message{Role: "assistant", Content: "thought about it"},
+				FinishReason: "stop",
+			}},
+		}
+	}
+	return resp, m.Trace, nil
+}
+
+// signedReasoningMock additionally satisfies the signedReasoningProvider
+// marker interface so the bridge surfaces Signed=true.
+type signedReasoningMock struct {
+	*reasoningCapableMock
+}
+
+func (signedReasoningMock) ReasoningTraceIsSigned() bool { return true }
+
+// imageReasoningCapableMock satisfies BOTH core.ImageProvider and
+// core.ReasoningProvider.
+type imageReasoningCapableMock struct {
+	*mockCoreProvider
+	LastImages []core.ImageInput
+	Trace      *core.ThinkingTrace
+}
+
+func (m *imageReasoningCapableMock) ChatWithImages(_ context.Context, req *core.ChatCompletionRequest, images []core.ImageInput) (*core.ChatCompletionResponse, error) {
+	m.LastRequest = req
+	m.LastImages = images
+	return &core.ChatCompletionResponse{
+		Choices: []core.ChatCompletionChoice{{Message: core.Message{Role: "assistant", Content: "img"}}},
+	}, nil
+}
+
+func (m *imageReasoningCapableMock) ChatWithReasoning(_ context.Context, req *core.ChatCompletionRequest) (*core.ChatCompletionResponse, *core.ThinkingTrace, error) {
+	m.LastRequest = req
+	return &core.ChatCompletionResponse{
+		Choices: []core.ChatCompletionChoice{{Message: core.Message{Role: "assistant", Content: "rsn"}}},
+	}, m.Trace, nil
+}
+
+// TestWrapCore_PlainProviderDoesNotPromote asserts a plain core.Provider
+// (no capabilities) wraps to a value that does NOT satisfy
+// common.ImageProvider or common.ReasoningProvider — so attack-module
+// type assertions correctly skip.
+func TestWrapCore_PlainProviderDoesNotPromote(t *testing.T) {
+	wrapped := WrapCore(&mockCoreProvider{})
+	if _, ok := wrapped.(common.ImageProvider); ok {
+		t.Error("plain provider promoted to common.ImageProvider; want skip")
+	}
+	if _, ok := wrapped.(common.ReasoningProvider); ok {
+		t.Error("plain provider promoted to common.ReasoningProvider; want skip")
+	}
+}
+
+// TestWrapCore_ImagePromotion asserts an underlying core.ImageProvider
+// surfaces as common.ImageProvider AND that QueryWithImages translates
+// the ImagePayload into a core.ImageInput.
+func TestWrapCore_ImagePromotion(t *testing.T) {
+	imgMock := &imageCapableMock{mockCoreProvider: &mockCoreProvider{}}
+	wrapped := WrapCore(imgMock)
+
+	ip, ok := wrapped.(common.ImageProvider)
+	if !ok {
+		t.Fatal("wrapper does not satisfy common.ImageProvider")
+	}
+	// Reasoning should NOT be promoted — only image is supported.
+	if _, ok := wrapped.(common.ReasoningProvider); ok {
+		t.Error("wrapper unexpectedly satisfies common.ReasoningProvider")
+	}
+
+	payload, err := common.NewImagePayloadBytes(
+		[]byte{0x89, 0x50, 0x4E, 0x47}, // PNG magic, just any bytes for the test
+		common.ImageMimePNG,
+		common.ImageDetailHigh,
+	)
+	if err != nil {
+		t.Fatalf("NewImagePayloadBytes: %v", err)
+	}
+
+	resp, err := ip.QueryWithImages(context.Background(), "what is this?", []common.ImagePayload{payload}, nil)
+	if err != nil {
+		t.Fatalf("QueryWithImages: %v", err)
+	}
+	if resp != "saw an image" {
+		t.Errorf("response = %q, want %q", resp, "saw an image")
+	}
+	if len(imgMock.LastImages) != 1 {
+		t.Fatalf("got %d images at core layer, want 1", len(imgMock.LastImages))
+	}
+	got := imgMock.LastImages[0]
+	if got.MimeType != "image/png" {
+		t.Errorf("MimeType = %q, want image/png", got.MimeType)
+	}
+	if got.Detail != "high" {
+		t.Errorf("Detail = %q, want high", got.Detail)
+	}
+	if len(got.Bytes) != 4 {
+		t.Errorf("Bytes len = %d, want 4", len(got.Bytes))
+	}
+}
+
+// TestWrapCore_ImagePromotion_RejectsEmptyImages asserts the bridge
+// fails fast on a zero-image call rather than dispatching to the
+// provider with an empty slice.
+func TestWrapCore_ImagePromotion_RejectsEmptyImages(t *testing.T) {
+	wrapped := WrapCore(&imageCapableMock{mockCoreProvider: &mockCoreProvider{}})
+	ip := wrapped.(common.ImageProvider)
+	_, err := ip.QueryWithImages(context.Background(), "x", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected 'at least one image required' error; got %v", err)
+	}
+}
+
+// TestWrapCore_ReasoningPromotion asserts an underlying
+// core.ReasoningProvider surfaces as common.ReasoningProvider AND that
+// QueryWithReasoning translates the ThinkingTrace.Steps into the
+// minimal ReasoningTrace.Steps shape modules consume.
+func TestWrapCore_ReasoningPromotion(t *testing.T) {
+	rsnMock := &reasoningCapableMock{
+		mockCoreProvider: &mockCoreProvider{},
+		Trace: &core.ThinkingTrace{
+			Steps: []core.ThinkingStep{
+				{Content: "first I considered X", Type: "summary"},
+				{Content: "then concluded Y", Type: "summary"},
+				{Content: "", Type: "summary"}, // empty step should be elided
+			},
+			TotalThinkingTokens: 1234,
+		},
+	}
+	wrapped := WrapCore(rsnMock)
+
+	rp, ok := wrapped.(common.ReasoningProvider)
+	if !ok {
+		t.Fatal("wrapper does not satisfy common.ReasoningProvider")
+	}
+	if _, ok := wrapped.(common.ImageProvider); ok {
+		t.Error("wrapper unexpectedly satisfies common.ImageProvider")
+	}
+
+	resp, trace, err := rp.QueryWithReasoning(context.Background(), []common.Message{
+		{Role: "user", Content: "solve X"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("QueryWithReasoning: %v", err)
+	}
+	if resp != "thought about it" {
+		t.Errorf("response = %q, want %q", resp, "thought about it")
+	}
+	if trace.Signed {
+		t.Error("trace.Signed = true for non-signed provider; want false")
+	}
+	if got := len(trace.Steps); got != 2 {
+		t.Errorf("Steps count = %d, want 2 (empty step should be elided)", got)
+	}
+	if trace.Steps[0] != "first I considered X" {
+		t.Errorf("Steps[0] = %q, want %q", trace.Steps[0], "first I considered X")
+	}
+}
+
+// TestWrapCore_ReasoningPromotion_SignedFlag asserts a core provider
+// marked via signedReasoningProvider surfaces Signed=true on the
+// returned trace. This is the v0.10.0 #166 hook for Anthropic's
+// extended-thinking signed-trace handling.
+func TestWrapCore_ReasoningPromotion_SignedFlag(t *testing.T) {
+	signed := signedReasoningMock{
+		reasoningCapableMock: &reasoningCapableMock{
+			mockCoreProvider: &mockCoreProvider{},
+			Trace:            &core.ThinkingTrace{Steps: []core.ThinkingStep{{Content: "step"}}},
+		},
+	}
+	wrapped := WrapCore(signed)
+	rp, ok := wrapped.(common.ReasoningProvider)
+	if !ok {
+		t.Fatal("wrapper does not satisfy common.ReasoningProvider")
+	}
+	_, trace, err := rp.QueryWithReasoning(context.Background(), []common.Message{{Role: "user", Content: "x"}}, nil)
+	if err != nil {
+		t.Fatalf("QueryWithReasoning: %v", err)
+	}
+	if !trace.Signed {
+		t.Error("trace.Signed = false for signed provider; want true")
+	}
+}
+
+// TestWrapCore_ImageReasoningPromotion asserts a provider supporting
+// BOTH capabilities returns a wrapper satisfying both interfaces, and
+// each capability method routes to the correct underlying provider.
+func TestWrapCore_ImageReasoningPromotion(t *testing.T) {
+	dual := &imageReasoningCapableMock{
+		mockCoreProvider: &mockCoreProvider{},
+		Trace:            &core.ThinkingTrace{Steps: []core.ThinkingStep{{Content: "thinking"}}},
+	}
+	wrapped := WrapCore(dual)
+
+	ip, okI := wrapped.(common.ImageProvider)
+	rp, okR := wrapped.(common.ReasoningProvider)
+	if !okI {
+		t.Fatal("dual-capable wrapper does not satisfy common.ImageProvider")
+	}
+	if !okR {
+		t.Fatal("dual-capable wrapper does not satisfy common.ReasoningProvider")
+	}
+
+	payload, _ := common.NewImagePayloadBytes(
+		[]byte{0x00, 0x01},
+		common.ImageMimeJPEG,
+		common.ImageDetailAuto,
+	)
+
+	imgResp, err := ip.QueryWithImages(context.Background(), "look", []common.ImagePayload{payload}, nil)
+	if err != nil {
+		t.Fatalf("QueryWithImages: %v", err)
+	}
+	if imgResp != "img" {
+		t.Errorf("image response = %q, want %q", imgResp, "img")
+	}
+
+	rsnResp, _, err := rp.QueryWithReasoning(context.Background(), []common.Message{{Role: "user", Content: "think"}}, nil)
+	if err != nil {
+		t.Fatalf("QueryWithReasoning: %v", err)
+	}
+	if rsnResp != "rsn" {
+		t.Errorf("reasoning response = %q, want %q", rsnResp, "rsn")
+	}
+}
+
+// TestWrapCore_ImagePromotion_URLPayload asserts URL-referenced
+// ImagePayloads round-trip with empty Bytes and the URL field set.
+func TestWrapCore_ImagePromotion_URLPayload(t *testing.T) {
+	imgMock := &imageCapableMock{mockCoreProvider: &mockCoreProvider{}}
+	wrapped := WrapCore(imgMock)
+	ip := wrapped.(common.ImageProvider)
+
+	payload, err := common.NewImagePayloadURL(
+		"https://example.com/x.png",
+		common.ImageMimePNG,
+		common.ImageDetailLow,
+	)
+	if err != nil {
+		t.Fatalf("NewImagePayloadURL: %v", err)
+	}
+	_, err = ip.QueryWithImages(context.Background(), "p", []common.ImagePayload{payload}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(imgMock.LastImages) != 1 {
+		t.Fatalf("got %d images, want 1", len(imgMock.LastImages))
+	}
+	got := imgMock.LastImages[0]
+	if got.URL != "https://example.com/x.png" {
+		t.Errorf("URL = %q, want %q", got.URL, "https://example.com/x.png")
+	}
+	if len(got.Bytes) != 0 {
+		t.Errorf("Bytes len = %d, want 0 for URL payload", len(got.Bytes))
+	}
+}
+
 // TestGetTokenCount_DelegatesToProvider asserts the wrapper calls
 // CountTokens on the inner provider.
 func TestGetTokenCount_DelegatesToProvider(t *testing.T) {

--- a/src/provider/core/capabilities.go
+++ b/src/provider/core/capabilities.go
@@ -46,6 +46,35 @@ type AudioProvider interface {
 	ChatWithAudio(ctx context.Context, request *ChatCompletionRequest, audio *AudioInput) (*ChatCompletionResponse, error)
 }
 
+// ImageProvider is implemented by providers that support image input alongside
+// text messages (e.g., GPT-4o vision, Claude 4.x vision, Gemini multimodal).
+//
+// v0.10.0 #166: this is the core-level capability that the bridge package
+// promotes into common.ImageProvider for attack-module type assertions.
+type ImageProvider interface {
+	Provider
+	// ChatWithImages sends a chat request with one or more attached images.
+	// Each ImageInput carries either inline Bytes or a URL reference, plus
+	// the MIME type and an advisory Detail hint that providers may honor or
+	// ignore at their discretion.
+	ChatWithImages(ctx context.Context, request *ChatCompletionRequest, images []ImageInput) (*ChatCompletionResponse, error)
+}
+
+// ImageInput contains a single image for ImageProvider.ChatWithImages. Exactly
+// one of Bytes / URL must be non-empty; the bridge package validates this when
+// converting from common.ImagePayload.
+type ImageInput struct {
+	// Bytes holds the inline image bytes. Mutually exclusive with URL.
+	Bytes []byte `json:"bytes,omitempty"`
+	// URL references an image hosted out-of-band. Mutually exclusive with Bytes.
+	URL string `json:"url,omitempty"`
+	// MimeType is the image MIME type (e.g., "image/jpeg", "image/png").
+	MimeType string `json:"mime_type"`
+	// Detail is an advisory hint to the provider ("low", "high", "auto").
+	// Providers that don't accept this hint silently ignore it.
+	Detail string `json:"detail,omitempty"`
+}
+
 // AudioInput contains audio data for providers that support audio input.
 type AudioInput struct {
 	// Data is the raw audio bytes.

--- a/src/provider/openai/reasoning.go
+++ b/src/provider/openai/reasoning.go
@@ -1,0 +1,241 @@
+// v0.10.0 #166 — OpenAI ReasoningProvider implementation via the Responses API.
+//
+// OpenAI's reasoning models (o3, o4-mini, gpt-5 reasoning class) expose
+// reasoning summaries through the Responses API at /v1/responses, NOT through
+// Chat Completions. The Responses API accepts an "input" array (role + content
+// strings) and returns an "output" array containing alternating "reasoning"
+// and "message" items. Each reasoning item carries a "summary" array of
+// summary_text entries — these become trace.Steps.
+//
+// trace.Signed is always false for OpenAI: the API returns the summary in
+// plaintext and accepts unsigned mutations on round-trip. Anthropic differs;
+// see the Anthropic adapter for the signed-trace path.
+//
+// Empty-trace handling: o3 omits the reasoning summary >90% of the time per
+// community reports. The bridge surfaces an empty trace.Steps; H-CoT then
+// emits SkipReasoningTraceEmpty after exhausting its retry budget.
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// ChatWithReasoning implements core.ReasoningProvider via the OpenAI
+// Responses API. The supplied request's Messages map to the input array;
+// MaxTokens / Temperature pass through. Reasoning summaries are extracted
+// into the returned ThinkingTrace; the final assistant text becomes the
+// ChatCompletionResponse's first choice.
+func (p *OpenAIProvider) ChatWithReasoning(ctx context.Context, request *core.ChatCompletionRequest) (*core.ChatCompletionResponse, *core.ThinkingTrace, error) {
+	type result struct {
+		resp  *core.ChatCompletionResponse
+		trace *core.ThinkingTrace
+	}
+	out, err := p.executeWithResilience(ctx, "ChatWithReasoning", request, func(ctx context.Context) (interface{}, error) {
+		resp, trace, err := p.chatWithReasoningFromAPI(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		return &result{resp: resp, trace: trace}, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	r := out.(*result)
+	return r.resp, r.trace, nil
+}
+
+// responsesRequest mirrors POST /v1/responses. The "include" array carries
+// the reasoning.encrypted_content flag so the response surface includes the
+// reasoning summary; reasoning.summary controls the verbosity ("auto",
+// "concise", "detailed").
+type responsesRequest struct {
+	Model           string                 `json:"model"`
+	Input           []responsesInputMessage `json:"input"`
+	Include         []string               `json:"include,omitempty"`
+	Reasoning       *responsesReasoningCfg `json:"reasoning,omitempty"`
+	MaxOutputTokens int                    `json:"max_output_tokens,omitempty"`
+	Temperature     float64                `json:"temperature,omitempty"`
+	TopP            float64                `json:"top_p,omitempty"`
+}
+
+type responsesInputMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type responsesReasoningCfg struct {
+	Summary string `json:"summary,omitempty"`
+}
+
+// responsesResponse is the /v1/responses output. Output items alternate
+// between "reasoning" (carrying summary entries) and "message" (carrying
+// the assistant's text). We accept either order and extract by item type.
+type responsesResponse struct {
+	ID     string             `json:"id"`
+	Model  string             `json:"model"`
+	Output []responsesOutput  `json:"output"`
+	Usage  *responsesUsage    `json:"usage,omitempty"`
+}
+
+type responsesOutput struct {
+	Type    string                   `json:"type"`
+	Summary []responsesSummaryItem   `json:"summary,omitempty"`
+	Content []responsesOutputContent `json:"content,omitempty"`
+}
+
+type responsesSummaryItem struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type responsesOutputContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type responsesUsage struct {
+	InputTokens         int `json:"input_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	OutputTokensDetails struct {
+		ReasoningTokens int `json:"reasoning_tokens"`
+	} `json:"output_tokens_details"`
+}
+
+func (p *OpenAIProvider) chatWithReasoningFromAPI(ctx context.Context, request *core.ChatCompletionRequest) (*core.ChatCompletionResponse, *core.ThinkingTrace, error) {
+	if request == nil {
+		return nil, nil, fmt.Errorf("openai: ChatWithReasoning: nil request")
+	}
+
+	model := request.Model
+	if model == "" {
+		if p.GetConfig().DefaultModel != "" {
+			model = p.GetConfig().DefaultModel
+		} else {
+			model = "o4-mini"
+		}
+	}
+
+	input := make([]responsesInputMessage, 0, len(request.Messages))
+	for _, m := range request.Messages {
+		input = append(input, responsesInputMessage{Role: m.Role, Content: m.Content})
+	}
+
+	body := responsesRequest{
+		Model:           model,
+		Input:           input,
+		Include:         []string{"reasoning.encrypted_content"},
+		Reasoning:       &responsesReasoningCfg{Summary: "detailed"},
+		MaxOutputTokens: request.MaxTokens,
+		Temperature:     request.Temperature,
+		TopP:            request.TopP,
+	}
+
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("openai: failed to marshal responses request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.GetConfig().BaseURL+"/responses", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, nil, fmt.Errorf("openai: failed to create responses request: %w", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+p.GetConfig().APIKey)
+	req.Header.Add("Content-Type", "application/json")
+	if p.GetConfig().OrgID != "" {
+		req.Header.Add("OpenAI-Organization", p.GetConfig().OrgID)
+	}
+	for k, v := range p.GetConfig().AdditionalHeaders {
+		req.Header.Add(k, v)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("openai: responses request failed: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Printf("openai: failed to close responses body: %v\n", cerr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("openai: failed to read responses body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	var rr responsesResponse
+	if err := json.Unmarshal(respBody, &rr); err != nil {
+		return nil, nil, fmt.Errorf("openai: failed to parse responses body: %w", err)
+	}
+
+	chatResp, trace := translateResponsesOutput(&rr)
+	return chatResp, trace, nil
+}
+
+// translateResponsesOutput pulls reasoning summaries into ThinkingTrace.Steps
+// and the assistant's message text into a single ChatCompletionResponse
+// choice. Multiple message outputs are concatenated (rare in practice; the
+// Responses API typically returns one).
+func translateResponsesOutput(rr *responsesResponse) (*core.ChatCompletionResponse, *core.ThinkingTrace) {
+	trace := &core.ThinkingTrace{}
+	var assistantText string
+
+	for _, out := range rr.Output {
+		switch out.Type {
+		case "reasoning":
+			for _, s := range out.Summary {
+				if s.Text != "" {
+					trace.Steps = append(trace.Steps, core.ThinkingStep{
+						Content: s.Text,
+						Type:    "summary",
+					})
+				}
+			}
+		case "message":
+			for _, c := range out.Content {
+				if c.Type == "output_text" {
+					assistantText += c.Text
+				}
+			}
+		}
+	}
+
+	if rr.Usage != nil {
+		trace.TotalThinkingTokens = rr.Usage.OutputTokensDetails.ReasoningTokens
+	}
+
+	chatResp := &core.ChatCompletionResponse{
+		ID:    rr.ID,
+		Model: rr.Model,
+		Choices: []core.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: core.Message{
+					Role:    "assistant",
+					Content: assistantText,
+				},
+				FinishReason: "stop",
+			},
+		},
+	}
+	if rr.Usage != nil {
+		chatResp.Usage = &core.TokenUsage{
+			PromptTokens:     rr.Usage.InputTokens,
+			CompletionTokens: rr.Usage.OutputTokens,
+			TotalTokens:      rr.Usage.InputTokens + rr.Usage.OutputTokens,
+		}
+	}
+	return chatResp, trace
+}
+
+var _ core.ReasoningProvider = (*OpenAIProvider)(nil)

--- a/src/provider/openai/reasoning_test.go
+++ b/src/provider/openai/reasoning_test.go
@@ -1,0 +1,171 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// TestChatWithReasoning_RequestShape asserts the wire body sent to
+// OpenAI's /v1/responses endpoint carries the include + reasoning
+// fields needed to surface the reasoning summary.
+func TestChatWithReasoning_RequestShape(t *testing.T) {
+	var captured responsesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/responses") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &captured); err != nil {
+			t.Errorf("unmarshal: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","model":"o4-mini","output":[
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"first I considered X"},{"type":"summary_text","text":"then concluded Y"}]},
+			{"type":"message","content":[{"type":"output_text","text":"the answer is 42"}]}
+		],"usage":{"input_tokens":10,"output_tokens":20,"output_tokens_details":{"reasoning_tokens":15}}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	resp, trace, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Model: "o4-mini",
+		Messages: []core.Message{
+			{Role: "user", Content: "what is 6*7?"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatWithReasoning: %v", err)
+	}
+
+	// Wire shape
+	if captured.Model != "o4-mini" {
+		t.Errorf("Model = %q, want o4-mini", captured.Model)
+	}
+	if len(captured.Include) == 0 || captured.Include[0] != "reasoning.encrypted_content" {
+		t.Errorf("Include = %v, want [reasoning.encrypted_content]", captured.Include)
+	}
+	if captured.Reasoning == nil || captured.Reasoning.Summary != "detailed" {
+		t.Errorf("Reasoning = %+v, want detailed", captured.Reasoning)
+	}
+	if got := len(captured.Input); got != 1 {
+		t.Fatalf("Input length = %d, want 1", got)
+	}
+	if captured.Input[0].Role != "user" || captured.Input[0].Content != "what is 6*7?" {
+		t.Errorf("Input[0] = %+v", captured.Input[0])
+	}
+
+	// Translated response shape
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Content != "the answer is 42" {
+		t.Errorf("Content = %q, want %q", resp.Choices[0].Message.Content, "the answer is 42")
+	}
+	if resp.Usage == nil || resp.Usage.PromptTokens != 10 || resp.Usage.CompletionTokens != 20 {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+
+	// Trace shape
+	if len(trace.Steps) != 2 {
+		t.Fatalf("trace.Steps = %d, want 2", len(trace.Steps))
+	}
+	if trace.Steps[0].Content != "first I considered X" {
+		t.Errorf("Steps[0] = %+v", trace.Steps[0])
+	}
+	if trace.TotalThinkingTokens != 15 {
+		t.Errorf("TotalThinkingTokens = %d, want 15", trace.TotalThinkingTokens)
+	}
+}
+
+// TestChatWithReasoning_EmptySummary asserts the documented o3 behavior:
+// the API sometimes omits the summary array; the bridge surfaces an
+// empty trace.Steps and the assistant message still resolves.
+func TestChatWithReasoning_EmptySummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/responses") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"r","output":[
+			{"type":"message","content":[{"type":"output_text","text":"42"}]}
+		]}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	resp, trace, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Model:    "o3",
+		Messages: []core.Message{{Role: "user", Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "42" {
+		t.Errorf("response = %q, want 42", resp.Choices[0].Message.Content)
+	}
+	if len(trace.Steps) != 0 {
+		t.Errorf("trace.Steps = %d, want 0 (empty-summary case)", len(trace.Steps))
+	}
+}
+
+// TestChatWithReasoning_DefaultsModel asserts the empty-Model fallback
+// uses o4-mini (the documented default).
+func TestChatWithReasoning_DefaultsModel(t *testing.T) {
+	var captured responsesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/responses") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		_, _ = w.Write([]byte(`{"id":"r","output":[]}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	// Override DefaultModel to empty to exercise the fallback.
+	p.GetConfig().DefaultModel = ""
+	_, _, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Messages: []core.Message{{Role: "user", Content: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured.Model != "o4-mini" {
+		t.Errorf("Model fallback = %q, want o4-mini", captured.Model)
+	}
+}
+
+// TestChatWithReasoning_PropagatesAPIError asserts non-200 surfaces an
+// error.
+func TestChatWithReasoning_PropagatesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/responses") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"message":"model not allowed"}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, _, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Messages: []core.Message{{Role: "user", Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "model not allowed") && !strings.Contains(err.Error(), "403") {
+		t.Errorf("err = %v, want substring 'model not allowed' or 403", err)
+	}
+}

--- a/src/provider/openai/vision.go
+++ b/src/provider/openai/vision.go
@@ -1,0 +1,208 @@
+// v0.10.0 #166 — OpenAI ImageProvider implementation.
+//
+// The Chat Completions API accepts a multimodal content array (text + image_url
+// parts) on user messages. Inline image bytes are base64-encoded as data: URLs;
+// URL refs pass through verbatim. The Detail hint is forwarded to OpenAI as the
+// image_url.detail field ("low" → fixed 85 tokens, "high" → tiled at 768px,
+// "auto" → server decides).
+//
+// This intentionally builds a separate request struct rather than reusing the
+// text-only ChatCompletion path: the wire shape diverges (content as array
+// vs string), and modeling them on one struct would force a pointer-y union
+// that obscures the diff between the two paths.
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// ChatWithImages implements core.ImageProvider.
+//
+// The supplied images are appended to the LAST user message in the request;
+// if no user message is present a synthetic empty-text user message is
+// appended to host the image parts. Existing system / assistant messages
+// pass through as plain text content parts so the wire shape stays
+// uniformly multimodal.
+func (p *OpenAIProvider) ChatWithImages(ctx context.Context, request *core.ChatCompletionRequest, images []core.ImageInput) (*core.ChatCompletionResponse, error) {
+	result, err := p.executeWithResilience(ctx, "ChatWithImages", request, func(ctx context.Context) (interface{}, error) {
+		return p.chatWithImagesFromAPI(ctx, request, images)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*core.ChatCompletionResponse), nil
+}
+
+// visionContentPart is one entry in a multimodal message's content array.
+// Exactly one of Text / ImageURL is populated per part, controlled by Type.
+type visionContentPart struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	ImageURL *visionImageURL `json:"image_url,omitempty"`
+}
+
+// visionImageURL is the image_url body for an image content part. Detail is
+// the OpenAI advisory hint; empty Detail leaves the field absent so the API
+// applies its default ("auto").
+type visionImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// visionMessage mirrors core.Message but with multimodal content parts.
+type visionMessage struct {
+	Role    string              `json:"role"`
+	Content []visionContentPart `json:"content"`
+	Name    string              `json:"name,omitempty"`
+}
+
+// visionRequest is the JSON body for /v1/chat/completions when sending
+// multimodal content. Only the fields the bridge passes through are
+// surfaced; richer Chat Completions params (tools, response_format, etc.)
+// can be added per acceptance-criteria growth.
+type visionRequest struct {
+	Model       string          `json:"model"`
+	Messages    []visionMessage `json:"messages"`
+	MaxTokens   int             `json:"max_tokens,omitempty"`
+	Temperature float64         `json:"temperature,omitempty"`
+	TopP        float64         `json:"top_p,omitempty"`
+	Stop        []string        `json:"stop,omitempty"`
+	N           int             `json:"n,omitempty"`
+}
+
+func (p *OpenAIProvider) chatWithImagesFromAPI(ctx context.Context, request *core.ChatCompletionRequest, images []core.ImageInput) (*core.ChatCompletionResponse, error) {
+	if request == nil {
+		return nil, fmt.Errorf("openai: ChatWithImages: nil request")
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("openai: ChatWithImages: at least one image required")
+	}
+
+	model := request.Model
+	if model == "" {
+		if p.GetConfig().DefaultModel != "" {
+			model = p.GetConfig().DefaultModel
+		} else {
+			model = "gpt-4o"
+		}
+	}
+
+	msgs := make([]visionMessage, 0, len(request.Messages))
+	for _, m := range request.Messages {
+		msgs = append(msgs, visionMessage{
+			Role:    m.Role,
+			Content: []visionContentPart{{Type: "text", Text: m.Content}},
+			Name:    m.Name,
+		})
+	}
+
+	imageParts := make([]visionContentPart, 0, len(images))
+	for i, img := range images {
+		url, err := encodeImageInputAsURL(img)
+		if err != nil {
+			return nil, fmt.Errorf("openai: image[%d]: %w", i, err)
+		}
+		imageParts = append(imageParts, visionContentPart{
+			Type:     "image_url",
+			ImageURL: &visionImageURL{URL: url, Detail: img.Detail},
+		})
+	}
+
+	attached := false
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "user" {
+			msgs[i].Content = append(msgs[i].Content, imageParts...)
+			attached = true
+			break
+		}
+	}
+	if !attached {
+		msgs = append(msgs, visionMessage{
+			Role:    "user",
+			Content: append([]visionContentPart{{Type: "text", Text: ""}}, imageParts...),
+		})
+	}
+
+	body := visionRequest{
+		Model:       model,
+		Messages:    msgs,
+		MaxTokens:   request.MaxTokens,
+		Temperature: request.Temperature,
+		TopP:        request.TopP,
+		Stop:        request.Stop,
+		N:           request.N,
+	}
+
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to marshal vision request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.GetConfig().BaseURL+"/chat/completions", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to create vision request: %w", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+p.GetConfig().APIKey)
+	req.Header.Add("Content-Type", "application/json")
+	if p.GetConfig().OrgID != "" {
+		req.Header.Add("OpenAI-Organization", p.GetConfig().OrgID)
+	}
+	for k, v := range p.GetConfig().AdditionalHeaders {
+		req.Header.Add(k, v)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai: vision request failed: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Printf("openai: failed to close vision response body: %v\n", cerr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to read vision response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	var response core.ChatCompletionResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("openai: failed to parse vision response: %w", err)
+	}
+	return &response, nil
+}
+
+// encodeImageInputAsURL converts a core.ImageInput into the URL-shape OpenAI
+// expects. Inline bytes become a data: URL with the MIME type prefix; URL
+// refs pass through verbatim. Mutual exclusion of Bytes vs URL is enforced
+// here so adapter callers can't sneak around the bridge's validation.
+func encodeImageInputAsURL(img core.ImageInput) (string, error) {
+	if img.URL != "" && len(img.Bytes) > 0 {
+		return "", fmt.Errorf("image input: both URL and Bytes set (mutually exclusive)")
+	}
+	if img.URL != "" {
+		return img.URL, nil
+	}
+	if len(img.Bytes) == 0 {
+		return "", fmt.Errorf("image input: empty (no URL or Bytes)")
+	}
+	if img.MimeType == "" {
+		return "", fmt.Errorf("image input: empty MimeType for inline bytes")
+	}
+	encoded := base64.StdEncoding.EncodeToString(img.Bytes)
+	return fmt.Sprintf("data:%s;base64,%s", img.MimeType, encoded), nil
+}
+
+var _ core.ImageProvider = (*OpenAIProvider)(nil)

--- a/src/provider/openai/vision_test.go
+++ b/src/provider/openai/vision_test.go
@@ -1,0 +1,280 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// newTestProvider returns an OpenAIProvider pointed at the given test
+// server, bypassing the heavyweight middleware setup used by
+// NewOpenAIProvider. The provider is concrete and exposes the methods
+// under test.
+func newTestProvider(t *testing.T, srv *httptest.Server) *OpenAIProvider {
+	t.Helper()
+	p, err := NewOpenAIProvider(&core.ProviderConfig{
+		Type:         core.OpenAIProvider,
+		APIKey:       "test-key",
+		BaseURL:      srv.URL,
+		DefaultModel: "gpt-4o",
+		Timeout:      5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAIProvider: %v", err)
+	}
+	op, ok := p.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("provider is not *OpenAIProvider: %T", p)
+	}
+	return op
+}
+
+// TestEncodeImageInputAsURL covers the URL/bytes mutual exclusion and
+// the data: URL formatting for inline-bytes inputs.
+func TestEncodeImageInputAsURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      core.ImageInput
+		want    string
+		wantErr string
+	}{
+		{
+			name: "url passes through",
+			in:   core.ImageInput{URL: "https://example.com/cat.jpg", MimeType: "image/jpeg"},
+			want: "https://example.com/cat.jpg",
+		},
+		{
+			name: "inline bytes encode as data URL",
+			in:   core.ImageInput{Bytes: []byte{0xFF, 0xD8, 0xFF}, MimeType: "image/jpeg"},
+			want: "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte{0xFF, 0xD8, 0xFF}),
+		},
+		{
+			name:    "both url and bytes is invalid",
+			in:      core.ImageInput{URL: "x", Bytes: []byte{1}, MimeType: "image/png"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "neither url nor bytes is invalid",
+			in:      core.ImageInput{MimeType: "image/png"},
+			wantErr: "empty",
+		},
+		{
+			name:    "inline bytes without mime is invalid",
+			in:      core.ImageInput{Bytes: []byte{1}},
+			wantErr: "MimeType",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := encodeImageInputAsURL(tc.in)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChatWithImages_RequestShape asserts the wire body sent to OpenAI
+// has the expected multimodal shape: messages[].content is an array
+// with text + image_url parts, and the image part carries the data URL
+// + Detail hint.
+func TestChatWithImages_RequestShape(t *testing.T) {
+	var captured visionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The provider's NewOpenAIProvider kicks off a GetModels call
+		// in a background goroutine; ignore it so the test only captures
+		// the chat completions body.
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &captured); err != nil {
+			t.Errorf("failed to unmarshal request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"r","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+
+	resp, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{
+			Messages: []core.Message{
+				{Role: "system", Content: "be helpful"},
+				{Role: "user", Content: "what is this?"},
+			},
+		},
+		[]core.ImageInput{
+			{Bytes: []byte{0x89, 0x50}, MimeType: "image/png", Detail: "high"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithImages: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "ok" {
+		t.Errorf("response content = %q, want %q", resp.Choices[0].Message.Content, "ok")
+	}
+
+	if captured.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want gpt-4o", captured.Model)
+	}
+	if got := len(captured.Messages); got != 2 {
+		t.Fatalf("messages count = %d, want 2", got)
+	}
+	user := captured.Messages[1]
+	if user.Role != "user" {
+		t.Errorf("messages[1].Role = %q, want user", user.Role)
+	}
+	if got := len(user.Content); got != 2 {
+		t.Fatalf("user.Content parts = %d, want 2 (text + image)", got)
+	}
+	if user.Content[0].Type != "text" || user.Content[0].Text != "what is this?" {
+		t.Errorf("text part wrong: %+v", user.Content[0])
+	}
+	if user.Content[1].Type != "image_url" {
+		t.Errorf("image part type = %q, want image_url", user.Content[1].Type)
+	}
+	if user.Content[1].ImageURL == nil {
+		t.Fatal("image_url missing")
+	}
+	if !strings.HasPrefix(user.Content[1].ImageURL.URL, "data:image/png;base64,") {
+		t.Errorf("image data URL = %q, want data:image/png;base64,...", user.Content[1].ImageURL.URL)
+	}
+	if user.Content[1].ImageURL.Detail != "high" {
+		t.Errorf("detail = %q, want high", user.Content[1].ImageURL.Detail)
+	}
+}
+
+// TestChatWithImages_AppendsSyntheticUserMessage asserts that when the
+// request has no user message (e.g., system-only), the bridge adds a
+// synthetic user message to host the image parts.
+func TestChatWithImages_AppendsSyntheticUserMessage(t *testing.T) {
+	var captured visionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{
+			Messages: []core.Message{{Role: "system", Content: "system only"}},
+		},
+		[]core.ImageInput{{URL: "https://x/y.png", MimeType: "image/png"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(captured.Messages); got != 2 {
+		t.Fatalf("messages = %d, want 2 (system + synthetic user)", got)
+	}
+	if captured.Messages[1].Role != "user" {
+		t.Errorf("synthetic message.Role = %q, want user", captured.Messages[1].Role)
+	}
+}
+
+// TestChatWithImages_RejectsEmpty asserts at-least-one-image guard.
+func TestChatWithImages_RejectsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server should not be called for empty-images request")
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+	p := newTestProvider(t, srv)
+	_, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{Messages: []core.Message{{Role: "user", Content: "hi"}}},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("err = %v, want 'at least one' error", err)
+	}
+}
+
+// TestChatWithImages_PropagatesAPIError asserts non-200 responses
+// surface as a typed *core.ProviderError.
+func TestChatWithImages_PropagatesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad image","type":"invalid_request_error"}}`))
+	}))
+	defer srv.Close()
+	p := newTestProvider(t, srv)
+
+	_, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{Messages: []core.Message{{Role: "user", Content: "x"}}},
+		[]core.ImageInput{{URL: "https://x/y.png", MimeType: "image/png"}},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	pe, ok := err.(*core.ProviderError)
+	if !ok {
+		// retry middleware may wrap, accept substring match on Error()
+		if !strings.Contains(err.Error(), "bad image") {
+			t.Fatalf("err = %v, want ProviderError or substring 'bad image'", err)
+		}
+		return
+	}
+	if pe.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want 400", pe.StatusCode)
+	}
+}
+
+// TestChatWithImages_AuthorizationHeader asserts the API key reaches
+// the request as a Bearer header — minimal smoke test for the
+// authentication wiring.
+func TestChatWithImages_AuthorizationHeader(t *testing.T) {
+	gotAuth := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+	p := newTestProvider(t, srv)
+	_, _ = p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{Messages: []core.Message{{Role: "user", Content: "x"}}},
+		[]core.ImageInput{{URL: "https://x/y.png", MimeType: "image/png"}},
+	)
+	if !strings.HasPrefix(gotAuth, "Bearer ") {
+		t.Errorf("Authorization header = %q, want Bearer prefix", gotAuth)
+	}
+}
+
+// silence unused-import lint when building without these.
+var _ = bytes.NewBuffer

--- a/src/provider/openai/vision_test.go
+++ b/src/provider/openai/vision_test.go
@@ -200,11 +200,19 @@ func TestChatWithImages_AppendsSyntheticUserMessage(t *testing.T) {
 	}
 }
 
-// TestChatWithImages_RejectsEmpty asserts at-least-one-image guard.
+// TestChatWithImages_RejectsEmpty asserts at-least-one-image guard. The
+// background GetModels goroutine kicked off by NewOpenAIProvider DOES
+// hit the server (on /v1/models); the assertion only fires for a
+// /chat/completions call, which would mean the empty-images guard
+// failed.
 func TestChatWithImages_RejectsEmpty(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Error("server should not be called for empty-images request")
-		w.WriteHeader(500)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			t.Error("server reached /chat/completions for empty-images request; the guard failed")
+			w.WriteHeader(500)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[]}`))
 	}))
 	defer srv.Close()
 	p := newTestProvider(t, srv)


### PR DESCRIPTION
Tier A of #166 — OpenAI side. Anthropic adapter wiring (Tier B) lands as a follow-up PR; the v0.10.0 plan documents OpenAI-only as the descope target if the full effort overruns.

## What this unblocks

Before this PR, every v0.9.0 attack module that type-asserts against \`common.ImageProvider\` (SIVA, VSH) or \`common.ReasoningProvider\` (H-CoT) emitted \`SkipMissingCapability\` against real OpenAI providers — no provider in the codebase implemented either capability. After this PR:

- \`siva\` / \`vsh\` actually run end-to-end against \`gpt-4o\` and other vision models.
- \`h_cot\` actually runs end-to-end against \`o3\` / \`o4-mini\` and other reasoning models.

## Architecture

### \`core/capabilities.go\` — new \`core.ImageProvider\`
Mirrors the existing \`core.AudioProvider\` shape. \`core.ImageInput\` carries Bytes-or-URL, MimeType, Detail. The bridge package validates mutual exclusion when converting from \`common.ImagePayload\`.

### \`openai/vision.go\` — Chat Completions multimodal
- Inline bytes → \`data:<mime>;base64,<...>\` URLs.
- URL refs pass through.
- Detail forwards as \`image_url.detail\`.
- Images attach to the LAST user message; if none, a synthetic empty user message hosts them.

### \`openai/reasoning.go\` — Responses API at \`/v1/responses\`
- \`include=[\"reasoning.encrypted_content\"]\`, \`reasoning.summary=\"detailed\"\`.
- Output translation: \`reasoning.summary[]\` → \`ThinkingTrace.Steps\`, \`message.content[].output_text\` → ChatCompletionResponse.
- Empty-summary case (o3 omits summary >90% of the time per community reports) surfaces as \`len(trace.Steps)==0\`. H-CoT then short-circuits to \`SkipReasoningTraceEmpty\` after retry budget.

### \`bridge/bridge.go\` — 2×2 capability promotion matrix
\`WrapCore\` now selects from four concrete wrapper types:

| Underlying core provider | Wrapper | common.* implemented |
|---|---|---|
| plain | \`coreAdapter\` | \`Provider\` |
| +ImageProvider | \`imageAdapter\` | \`Provider\` + \`ImageProvider\` |
| +ReasoningProvider | \`reasoningAdapter\` | \`Provider\` + \`ReasoningProvider\` |
| +both | \`imageReasoningAdapter\` | all three |

Four concrete types instead of one struct with always-present methods because Go's type assertion is structural at compile time: a single struct with \`QueryWithImages\` would always satisfy \`common.ImageProvider\` regardless of underlying capability, defeating the gate attack modules use to detect support. Modules need OK to mean \"this provider really does images,\" not \"the wrapper has the method.\"

\`signedReasoningProvider\` marker: any core provider implementing \`ReasoningTraceIsSigned() bool\` surfaces \`trace.Signed=true\`. This is the hook for Anthropic's extended-thinking signed-trace handling in PR B.

Compile-time interface checks at the bottom of \`bridge.go\` fail fast if a wrapper stops satisfying its claimed contract.

## Test coverage

- \`bridge_test.go\` — 8 new tests covering plain non-promotion, image promotion + ImagePayload translation, reasoning promotion + step filtering, signed-flag forwarding, dual-capable promotion, URL payload shape, empty-images guard.
- \`openai/vision_test.go\` — \`encodeImageInputAsURL\` table test (5 cases), request-shape via httptest, synthetic-user fallback, empty-images guard, API error propagation, auth header.
- \`openai/reasoning_test.go\` — Responses API request shape, empty-summary case, default-model fallback, API error propagation.

All test handlers filter by URL path so the async \`GetModels\` goroutine kicked off by \`NewOpenAIProvider\` doesn't race with the call under test.

## Acceptance criteria progress (from #166)

- [x] OpenAI adapter implements both \`ImageProvider\` and \`ReasoningProvider\`
- [ ] Anthropic adapter implements both interfaces — **Tier B follow-up PR**
- [x] \`RUN_INTEGRATION=1 go test ./src/attacks/integration/...\` passes with mocks
- [x] H-CoT against an OpenAI reasoning model: bridge surfaces \`Success\`/\`Refused\`/empty-trace correctly (live verification needs API key + reasoning model — covered by httptest unit tests for the bridge contract)
- [ ] H-CoT against Anthropic emits \`SkipSignatureGated\` deterministically — **Tier B**
- [ ] Round-trip image upload + reasoning-trace tests gated by \`RUN_INTEGRATION=1\` + \`OPENAI_API_KEY\` — covered by the httptest-based unit tests in this PR; live API tests deferred to follow-up

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./src/provider/openai/ -count=1\` — 12 new tests pass
- [x] \`go test ./src/provider/bridge/ -count=1\` — 21 tests pass (13 existing + 8 new)
- [x] \`go test ./... -count=1\` — full suite green
- [x] \`RUN_INTEGRATION=1 go test ./src/attacks/integration/\` — pass
- [x] \`bash scripts/verify-drift.sh\` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image inputs are now supported for OpenAI provider queries
  * Reasoning traces are now available for OpenAI provider requests
  * Automatic capability detection promotes image and reasoning features when underlying providers support them

<!-- end of auto-generated comment: release notes by coderabbit.ai -->