### PR TITLE
feat(provider/anthropic): #166 (Tier B) ImageProvider + ReasoningProvider wiring

### DIFF
--- a/src/provider/anthropic/reasoning.go
+++ b/src/provider/anthropic/reasoning.go
@@ -1,0 +1,267 @@
+// v0.10.0 #166 (Tier B) — Anthropic ReasoningProvider via extended thinking.
+//
+// Anthropic's extended thinking API returns a content array with two block
+// types interleaved: "thinking" (reasoning steps) and "text" (assistant
+// response). Each thinking block carries a "signature" field — a
+// cryptographic signature over the thinking text. Modifying the text on
+// round-trip breaks the signature and the API rejects subsequent calls.
+//
+// The signature drives v0.9.0's H-CoT signed-trace short-circuit:
+// modules detecting Signed=true emit OutcomeSkipped + SkipSignatureGated
+// rather than wasting attempts on mutations that the API will silently
+// discard. This adapter declares Signed=true via the bridge's
+// signedReasoningProvider marker interface.
+//
+// Request shape (Messages API):
+//
+//	{
+//	  "model": "claude-opus-4-5",
+//	  "max_tokens": 16000,
+//	  "thinking": {"type": "enabled", "budget_tokens": 10000},
+//	  "messages": [...]
+//	}
+//
+// Response shape:
+//
+//	{
+//	  "content": [
+//	    {"type":"thinking","thinking":"...", "signature":"..."},
+//	    {"type":"text","text":"..."}
+//	  ],
+//	  "usage": {"input_tokens":..., "output_tokens":...}
+//	}
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// ChatWithReasoning implements core.ReasoningProvider via the Anthropic
+// Messages API's extended-thinking mode. Reasoning blocks become
+// ThinkingTrace.Steps; the assistant text becomes the response choice.
+func (p *AnthropicProvider) ChatWithReasoning(ctx context.Context, request *core.ChatCompletionRequest) (*core.ChatCompletionResponse, *core.ThinkingTrace, error) {
+	type result struct {
+		resp  *core.ChatCompletionResponse
+		trace *core.ThinkingTrace
+	}
+	out, err := p.executeWithResilience(ctx, "ChatWithReasoning", request, func(ctx context.Context) (interface{}, error) {
+		resp, trace, err := p.chatWithReasoningFromAPI(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		return &result{resp: resp, trace: trace}, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	r := out.(*result)
+	return r.resp, r.trace, nil
+}
+
+// ReasoningTraceIsSigned satisfies the bridge's signedReasoningProvider
+// marker. Anthropic's thinking blocks always carry a signature — modules
+// must treat the trace as immutable on round-trip.
+func (p *AnthropicProvider) ReasoningTraceIsSigned() bool { return true }
+
+// anthropicReasoningRequest is the JSON body for /v1/messages with
+// extended-thinking enabled. ThinkingBudget bounds reasoning tokens —
+// the field is required when Thinking.Type="enabled".
+type anthropicReasoningRequest struct {
+	Model       string                       `json:"model"`
+	System      string                       `json:"system,omitempty"`
+	Messages    []anthropicReasoningMessage  `json:"messages"`
+	MaxTokens   int                          `json:"max_tokens"`
+	Thinking    *anthropicThinkingCfg        `json:"thinking,omitempty"`
+	Temperature float64                      `json:"temperature,omitempty"`
+	TopP        float64                      `json:"top_p,omitempty"`
+	Stop        []string                     `json:"stop_sequences,omitempty"`
+}
+
+type anthropicReasoningMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicThinkingCfg struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens"`
+}
+
+// anthropicReasoningResponse mirrors the /v1/messages response when
+// extended thinking is enabled. Content blocks alternate between
+// thinking and text types.
+type anthropicReasoningResponse struct {
+	ID         string                       `json:"id"`
+	Model      string                       `json:"model"`
+	StopReason string                       `json:"stop_reason"`
+	Content    []anthropicReasoningContent  `json:"content"`
+	Usage      anthropicReasoningUsage      `json:"usage"`
+}
+
+type anthropicReasoningContent struct {
+	Type      string `json:"type"`
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	Text      string `json:"text,omitempty"`
+}
+
+type anthropicReasoningUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// defaultThinkingBudgetTokens is the default reasoning-token budget when
+// the operator doesn't specify one. 10K is the documented sweet spot for
+// most reasoning tasks; Anthropic accepts up to model-specific maxima
+// (Opus 4 supports 64K).
+const defaultThinkingBudgetTokens = 10000
+
+func (p *AnthropicProvider) chatWithReasoningFromAPI(ctx context.Context, request *core.ChatCompletionRequest) (*core.ChatCompletionResponse, *core.ThinkingTrace, error) {
+	if request == nil {
+		return nil, nil, fmt.Errorf("anthropic: ChatWithReasoning: nil request")
+	}
+
+	model := request.Model
+	if model == "" {
+		if p.GetConfig().DefaultModel != "" {
+			model = p.GetConfig().DefaultModel
+		} else {
+			model = "claude-opus-4-5"
+		}
+	}
+
+	var system string
+	msgs := make([]anthropicReasoningMessage, 0, len(request.Messages))
+	for _, m := range request.Messages {
+		if m.Role == "system" {
+			if system == "" {
+				system = m.Content
+			} else {
+				system = system + "\n\n" + m.Content
+			}
+			continue
+		}
+		msgs = append(msgs, anthropicReasoningMessage{Role: m.Role, Content: m.Content})
+	}
+
+	maxTok := request.MaxTokens
+	if maxTok <= 0 {
+		// Extended thinking requires max_tokens >= budget_tokens. Pick a
+		// generous default so the budget can fit alongside the response.
+		maxTok = defaultThinkingBudgetTokens + 4096
+	}
+
+	body := anthropicReasoningRequest{
+		Model:    model,
+		System:   system,
+		Messages: msgs,
+		MaxTokens: maxTok,
+		Thinking: &anthropicThinkingCfg{
+			Type:         "enabled",
+			BudgetTokens: defaultThinkingBudgetTokens,
+		},
+		Temperature: request.Temperature,
+		TopP:        request.TopP,
+		Stop:        request.Stop,
+	}
+
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("anthropic: failed to marshal reasoning request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.GetConfig().BaseURL+"/v1/messages", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, nil, fmt.Errorf("anthropic: failed to create reasoning request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", p.GetConfig().APIKey)
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("X-Api-Client", "anthropic-LLMrecon/1.0.0")
+	for k, v := range p.GetConfig().AdditionalHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("anthropic: reasoning request failed: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Printf("anthropic: failed to close reasoning response body: %v\n", cerr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("anthropic: failed to read reasoning response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	var rr anthropicReasoningResponse
+	if err := json.Unmarshal(respBody, &rr); err != nil {
+		return nil, nil, fmt.Errorf("anthropic: failed to parse reasoning response: %w", err)
+	}
+
+	chatResp, trace := translateAnthropicReasoningOutput(&rr)
+	return chatResp, trace, nil
+}
+
+// translateAnthropicReasoningOutput pulls thinking blocks into trace.Steps
+// (preserving signature presence implicitly via Signed=true at the
+// adapter level) and concatenates text blocks into the assistant message.
+func translateAnthropicReasoningOutput(rr *anthropicReasoningResponse) (*core.ChatCompletionResponse, *core.ThinkingTrace) {
+	trace := &core.ThinkingTrace{
+		TotalThinkingTokens: rr.Usage.OutputTokens, // Anthropic doesn't break out thinking vs response tokens; OutputTokens is the closest scalar.
+	}
+	var assistantText string
+
+	for _, c := range rr.Content {
+		switch c.Type {
+		case "thinking":
+			if c.Thinking != "" {
+				trace.Steps = append(trace.Steps, core.ThinkingStep{
+					Content: c.Thinking,
+					Type:    "thinking",
+				})
+			}
+		case "text":
+			assistantText += c.Text
+		}
+	}
+
+	chatResp := &core.ChatCompletionResponse{
+		ID:      rr.ID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   rr.Model,
+		Choices: []core.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: core.Message{
+					Role:    "assistant",
+					Content: assistantText,
+				},
+				FinishReason: convertStopReasonToFinishReason(rr.StopReason),
+			},
+		},
+		Usage: &core.TokenUsage{
+			PromptTokens:     rr.Usage.InputTokens,
+			CompletionTokens: rr.Usage.OutputTokens,
+			TotalTokens:      rr.Usage.InputTokens + rr.Usage.OutputTokens,
+		},
+	}
+	return chatResp, trace
+}
+
+var _ core.ReasoningProvider = (*AnthropicProvider)(nil)

--- a/src/provider/anthropic/reasoning_test.go
+++ b/src/provider/anthropic/reasoning_test.go
@@ -1,0 +1,188 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// TestReasoningTraceIsSigned asserts the marker interface returns true.
+// This is the load-bearing assertion for v0.9.0's H-CoT short-circuit:
+// once the bridge promotes via signedReasoningProvider, modules emit
+// SkipSignatureGated against Anthropic.
+func TestReasoningTraceIsSigned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+	p := newTestProvider(t, srv)
+	if !p.ReasoningTraceIsSigned() {
+		t.Error("ReasoningTraceIsSigned = false, want true for Anthropic")
+	}
+}
+
+// TestChatWithReasoning_RequestShape asserts the wire body sent to
+// /v1/messages includes the thinking config block with budget_tokens.
+func TestChatWithReasoning_RequestShape(t *testing.T) {
+	var captured anthropicReasoningRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &captured); err != nil {
+			t.Errorf("unmarshal: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","model":"claude-opus-4-5","stop_reason":"end_turn","content":[
+			{"type":"thinking","thinking":"first I considered X","signature":"sig1=="},
+			{"type":"thinking","thinking":"then concluded Y","signature":"sig2=="},
+			{"type":"text","text":"the answer is 42"}
+		],"usage":{"input_tokens":10,"output_tokens":20}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	resp, trace, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Model: "claude-opus-4-5",
+		Messages: []core.Message{
+			{Role: "system", Content: "be concise"},
+			{Role: "user", Content: "what is 6*7?"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatWithReasoning: %v", err)
+	}
+
+	// Wire shape
+	if captured.Model != "claude-opus-4-5" {
+		t.Errorf("Model = %q", captured.Model)
+	}
+	if captured.System != "be concise" {
+		t.Errorf("System = %q", captured.System)
+	}
+	if captured.Thinking == nil {
+		t.Fatal("Thinking config absent in request")
+	}
+	if captured.Thinking.Type != "enabled" {
+		t.Errorf("Thinking.Type = %q, want enabled", captured.Thinking.Type)
+	}
+	if captured.Thinking.BudgetTokens != defaultThinkingBudgetTokens {
+		t.Errorf("Thinking.BudgetTokens = %d, want %d", captured.Thinking.BudgetTokens, defaultThinkingBudgetTokens)
+	}
+	if captured.MaxTokens < captured.Thinking.BudgetTokens {
+		t.Errorf("MaxTokens %d must >= BudgetTokens %d", captured.MaxTokens, captured.Thinking.BudgetTokens)
+	}
+	if got := len(captured.Messages); got != 1 {
+		t.Fatalf("messages = %d, want 1 (system extracted)", got)
+	}
+
+	// Translated response
+	if resp.Choices[0].Message.Content != "the answer is 42" {
+		t.Errorf("response content = %q", resp.Choices[0].Message.Content)
+	}
+	if resp.Usage == nil || resp.Usage.PromptTokens != 10 || resp.Usage.CompletionTokens != 20 {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+
+	// Trace
+	if len(trace.Steps) != 2 {
+		t.Fatalf("trace.Steps = %d, want 2", len(trace.Steps))
+	}
+	if trace.Steps[0].Content != "first I considered X" {
+		t.Errorf("Steps[0] = %+v", trace.Steps[0])
+	}
+	if trace.Steps[0].Type != "thinking" {
+		t.Errorf("Steps[0].Type = %q, want thinking", trace.Steps[0].Type)
+	}
+	if trace.TotalThinkingTokens != 20 {
+		t.Errorf("TotalThinkingTokens = %d, want 20", trace.TotalThinkingTokens)
+	}
+}
+
+// TestChatWithReasoning_DefaultsModel asserts the empty-Model fallback.
+func TestChatWithReasoning_DefaultsModel(t *testing.T) {
+	var captured anthropicReasoningRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		_, _ = w.Write([]byte(`{"id":"r","model":"claude-opus-4-5","content":[],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	p.GetConfig().DefaultModel = "" // exercise fallback path
+	_, _, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Messages: []core.Message{{Role: "user", Content: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured.Model != "claude-opus-4-5" {
+		t.Errorf("Model fallback = %q, want claude-opus-4-5", captured.Model)
+	}
+}
+
+// TestChatWithReasoning_PropagatesAPIError asserts non-200 responses
+// surface as an error.
+func TestChatWithReasoning_PropagatesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"max_tokens too small"}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, _, err := p.ChatWithReasoning(context.Background(), &core.ChatCompletionRequest{
+		Messages: []core.Message{{Role: "user", Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "max_tokens too small") && !strings.Contains(err.Error(), "400") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+// TestChatWithReasoning_BridgeSurfacesSigned asserts the cross-package
+// integration: a reasoning provider implementing
+// signedReasoningProvider routes its bool through to common.ReasoningTrace.Signed.
+//
+// The bridge package's signedReasoningProvider interface is unexported,
+// so we exercise the contract by checking common.ReasoningProvider via
+// the bridge's WrapCore. The Anthropic provider's
+// ReasoningTraceIsSigned() returns true, so the wrapped trace should
+// have Signed=true.
+//
+// This test lives here (not in bridge_test.go) because importing the
+// concrete Anthropic provider into bridge tests would create a
+// dependency cycle.
+func TestChatWithReasoning_BridgeSurfacesSigned(t *testing.T) {
+	// We can only check the local invariant — the cross-package
+	// promotion is exercised in bridge_test.go's
+	// TestWrapCore_ReasoningPromotion_SignedFlag with a mock that
+	// satisfies the same interface.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+	p := newTestProvider(t, srv)
+	if !p.ReasoningTraceIsSigned() {
+		t.Error("Anthropic provider must declare signed traces")
+	}
+}

--- a/src/provider/anthropic/vision.go
+++ b/src/provider/anthropic/vision.go
@@ -1,0 +1,265 @@
+// v0.10.0 #166 (Tier B) — Anthropic ImageProvider implementation.
+//
+// The Messages API accepts content blocks with type=image. Inline bytes
+// encode as base64 source blocks (source.type="base64"); URL refs encode
+// as url source blocks (source.type="url"). The MimeType maps to
+// source.media_type for base64 inputs.
+//
+// Anthropic does NOT accept the Detail hint — there's no equivalent API
+// field. Per the v0.10.0 #166 issue: "silently ignore Detail() (Anthropic
+// API doesn't accept the hint)." The bridge passes Detail through but
+// this adapter drops it on the floor.
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// ChatWithImages implements core.ImageProvider via the Messages API
+// content-block shape. Images attach to the LAST user message; if none,
+// a synthetic empty user message hosts them. System messages remain in
+// the top-level "system" field per Anthropic convention.
+func (p *AnthropicProvider) ChatWithImages(ctx context.Context, request *core.ChatCompletionRequest, images []core.ImageInput) (*core.ChatCompletionResponse, error) {
+	result, err := p.executeWithResilience(ctx, "ChatWithImages", request, func(ctx context.Context) (interface{}, error) {
+		return p.chatWithImagesFromAPI(ctx, request, images)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*core.ChatCompletionResponse), nil
+}
+
+// anthropicMessage is one entry in the Messages API "messages" array.
+// Content is the polymorphic block array (text, image).
+type anthropicMessage struct {
+	Role    string                  `json:"role"`
+	Content []anthropicContentBlock `json:"content"`
+}
+
+// anthropicContentBlock is a single content block. Exactly one of Text /
+// Source is populated per block, controlled by Type.
+type anthropicContentBlock struct {
+	Type   string                `json:"type"`
+	Text   string                `json:"text,omitempty"`
+	Source *anthropicImageSource `json:"source,omitempty"`
+}
+
+// anthropicImageSource carries the image data per Anthropic's Messages API:
+//
+//	{ "type": "base64", "media_type": "image/jpeg", "data": "<b64>" }
+//	{ "type": "url",    "url": "https://..." }
+//
+// MediaType is required for base64; URL form ignores it.
+type anthropicImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+// anthropicVisionRequest is the JSON body for /v1/messages when sending
+// multimodal content. Mirrors the existing ChatCompletion path's shape
+// but with explicit content blocks.
+type anthropicVisionRequest struct {
+	Model       string             `json:"model"`
+	System      string             `json:"system,omitempty"`
+	Messages    []anthropicMessage `json:"messages"`
+	MaxTokens   int                `json:"max_tokens,omitempty"`
+	Temperature float64            `json:"temperature,omitempty"`
+	TopP        float64            `json:"top_p,omitempty"`
+	Stop        []string           `json:"stop_sequences,omitempty"`
+}
+
+func (p *AnthropicProvider) chatWithImagesFromAPI(ctx context.Context, request *core.ChatCompletionRequest, images []core.ImageInput) (*core.ChatCompletionResponse, error) {
+	if request == nil {
+		return nil, fmt.Errorf("anthropic: ChatWithImages: nil request")
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("anthropic: ChatWithImages: at least one image required")
+	}
+
+	model := request.Model
+	if model == "" {
+		if p.GetConfig().DefaultModel != "" {
+			model = p.GetConfig().DefaultModel
+		} else {
+			model = "claude-opus-4-5"
+		}
+	}
+
+	// Anthropic puts system messages in a top-level field, not in messages.
+	var system string
+	msgs := make([]anthropicMessage, 0, len(request.Messages))
+	for _, m := range request.Messages {
+		if m.Role == "system" {
+			if system == "" {
+				system = m.Content
+			} else {
+				system = system + "\n\n" + m.Content
+			}
+			continue
+		}
+		msgs = append(msgs, anthropicMessage{
+			Role:    m.Role,
+			Content: []anthropicContentBlock{{Type: "text", Text: m.Content}},
+		})
+	}
+
+	imageBlocks := make([]anthropicContentBlock, 0, len(images))
+	for i, img := range images {
+		src, err := buildAnthropicImageSource(img)
+		if err != nil {
+			return nil, fmt.Errorf("anthropic: image[%d]: %w", i, err)
+		}
+		imageBlocks = append(imageBlocks, anthropicContentBlock{
+			Type:   "image",
+			Source: src,
+		})
+	}
+
+	attached := false
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "user" {
+			msgs[i].Content = append(msgs[i].Content, imageBlocks...)
+			attached = true
+			break
+		}
+	}
+	if !attached {
+		msgs = append(msgs, anthropicMessage{
+			Role:    "user",
+			Content: append([]anthropicContentBlock{{Type: "text", Text: ""}}, imageBlocks...),
+		})
+	}
+
+	// Anthropic requires max_tokens; default 4096 if not supplied.
+	maxTok := request.MaxTokens
+	if maxTok <= 0 {
+		maxTok = 4096
+	}
+
+	body := anthropicVisionRequest{
+		Model:       model,
+		System:      system,
+		Messages:    msgs,
+		MaxTokens:   maxTok,
+		Temperature: request.Temperature,
+		TopP:        request.TopP,
+		Stop:        request.Stop,
+	}
+
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: failed to marshal vision request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.GetConfig().BaseURL+"/v1/messages", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: failed to create vision request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", p.GetConfig().APIKey)
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("X-Api-Client", "anthropic-LLMrecon/1.0.0")
+	for k, v := range p.GetConfig().AdditionalHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: vision request failed: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Printf("anthropic: failed to close vision response body: %v\n", cerr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: failed to read vision response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	var raw struct {
+		ID         string `json:"id"`
+		Model      string `json:"model"`
+		StopReason string `json:"stop_reason"`
+		Content    []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("anthropic: failed to parse vision response: %w", err)
+	}
+
+	var assistant string
+	for _, c := range raw.Content {
+		if c.Type == "text" {
+			assistant += c.Text
+		}
+	}
+
+	return &core.ChatCompletionResponse{
+		ID:      raw.ID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   raw.Model,
+		Choices: []core.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: core.Message{
+					Role:    "assistant",
+					Content: assistant,
+				},
+				FinishReason: convertStopReasonToFinishReason(raw.StopReason),
+			},
+		},
+		Usage: &core.TokenUsage{
+			PromptTokens:     raw.Usage.InputTokens,
+			CompletionTokens: raw.Usage.OutputTokens,
+			TotalTokens:      raw.Usage.InputTokens + raw.Usage.OutputTokens,
+		},
+	}, nil
+}
+
+// buildAnthropicImageSource constructs the source block per image-input
+// type. URL refs become source.type="url"; inline bytes become
+// source.type="base64" + media_type. Mutual exclusion enforced.
+func buildAnthropicImageSource(img core.ImageInput) (*anthropicImageSource, error) {
+	if img.URL != "" && len(img.Bytes) > 0 {
+		return nil, fmt.Errorf("image input: both URL and Bytes set (mutually exclusive)")
+	}
+	if img.URL != "" {
+		return &anthropicImageSource{Type: "url", URL: img.URL}, nil
+	}
+	if len(img.Bytes) == 0 {
+		return nil, fmt.Errorf("image input: empty (no URL or Bytes)")
+	}
+	if img.MimeType == "" {
+		return nil, fmt.Errorf("image input: empty MimeType for inline bytes")
+	}
+	return &anthropicImageSource{
+		Type:      "base64",
+		MediaType: img.MimeType,
+		Data:      base64.StdEncoding.EncodeToString(img.Bytes),
+	}, nil
+}
+
+var _ core.ImageProvider = (*AnthropicProvider)(nil)

--- a/src/provider/anthropic/vision_test.go
+++ b/src/provider/anthropic/vision_test.go
@@ -1,0 +1,258 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// newTestProvider returns an AnthropicProvider pointed at the given
+// httptest server. Mirrors the OpenAI test helper.
+func newTestProvider(t *testing.T, srv *httptest.Server) *AnthropicProvider {
+	t.Helper()
+	p, err := NewAnthropicProvider(&core.ProviderConfig{
+		Type:         core.AnthropicProvider,
+		APIKey:       "test-key",
+		BaseURL:      srv.URL,
+		DefaultModel: "claude-opus-4-5",
+		Timeout:      5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewAnthropicProvider: %v", err)
+	}
+	ap, ok := p.(*AnthropicProvider)
+	if !ok {
+		t.Fatalf("provider is not *AnthropicProvider: %T", p)
+	}
+	return ap
+}
+
+// TestBuildAnthropicImageSource covers URL/bytes mutual exclusion and
+// the base64 + media_type wire shape.
+func TestBuildAnthropicImageSource(t *testing.T) {
+	cases := []struct {
+		name           string
+		in             core.ImageInput
+		wantType       string
+		wantURL        string
+		wantMediaType  string
+		wantDataPrefix string
+		wantErr        string
+	}{
+		{
+			name:     "url passes through",
+			in:       core.ImageInput{URL: "https://example.com/cat.jpg"},
+			wantType: "url",
+			wantURL:  "https://example.com/cat.jpg",
+		},
+		{
+			name:           "inline bytes encode as base64",
+			in:             core.ImageInput{Bytes: []byte{0xFF, 0xD8, 0xFF}, MimeType: "image/jpeg"},
+			wantType:       "base64",
+			wantMediaType:  "image/jpeg",
+			wantDataPrefix: base64.StdEncoding.EncodeToString([]byte{0xFF, 0xD8, 0xFF}),
+		},
+		{
+			name:    "both url and bytes is invalid",
+			in:      core.ImageInput{URL: "x", Bytes: []byte{1}, MimeType: "image/png"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "neither is invalid",
+			in:      core.ImageInput{MimeType: "image/png"},
+			wantErr: "empty",
+		},
+		{
+			name:    "inline bytes without mime is invalid",
+			in:      core.ImageInput{Bytes: []byte{1}},
+			wantErr: "MimeType",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildAnthropicImageSource(tc.in)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if got.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", got.Type, tc.wantType)
+			}
+			if got.URL != tc.wantURL {
+				t.Errorf("URL = %q, want %q", got.URL, tc.wantURL)
+			}
+			if got.MediaType != tc.wantMediaType {
+				t.Errorf("MediaType = %q, want %q", got.MediaType, tc.wantMediaType)
+			}
+			if tc.wantDataPrefix != "" && got.Data != tc.wantDataPrefix {
+				t.Errorf("Data = %q, want %q", got.Data, tc.wantDataPrefix)
+			}
+		})
+	}
+}
+
+// TestChatWithImages_RequestShape asserts the wire body sent to
+// Anthropic /v1/messages carries content blocks with the right shape:
+// system text in top-level "system", text + image blocks in user message.
+func TestChatWithImages_RequestShape(t *testing.T) {
+	var captured anthropicVisionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &captured); err != nil {
+			t.Errorf("unmarshal: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","model":"claude-opus-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"saw a cat"}],"usage":{"input_tokens":10,"output_tokens":5}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	resp, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{
+			Messages: []core.Message{
+				{Role: "system", Content: "be helpful"},
+				{Role: "user", Content: "what is this?"},
+			},
+		},
+		[]core.ImageInput{
+			{Bytes: []byte{0x89, 0x50}, MimeType: "image/png"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithImages: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "saw a cat" {
+		t.Errorf("response = %q, want %q", resp.Choices[0].Message.Content, "saw a cat")
+	}
+
+	if captured.Model != "claude-opus-4-5" {
+		t.Errorf("Model = %q, want claude-opus-4-5", captured.Model)
+	}
+	if captured.System != "be helpful" {
+		t.Errorf("System = %q, want %q", captured.System, "be helpful")
+	}
+	if got := len(captured.Messages); got != 1 {
+		t.Fatalf("messages count = %d, want 1 (system extracted to top-level)", got)
+	}
+	user := captured.Messages[0]
+	if user.Role != "user" {
+		t.Errorf("messages[0].Role = %q, want user", user.Role)
+	}
+	if got := len(user.Content); got != 2 {
+		t.Fatalf("user.Content blocks = %d, want 2 (text + image)", got)
+	}
+	if user.Content[0].Type != "text" || user.Content[0].Text != "what is this?" {
+		t.Errorf("text block wrong: %+v", user.Content[0])
+	}
+	if user.Content[1].Type != "image" {
+		t.Errorf("image block type = %q, want image", user.Content[1].Type)
+	}
+	if user.Content[1].Source == nil || user.Content[1].Source.Type != "base64" {
+		t.Errorf("image source wrong: %+v", user.Content[1].Source)
+	}
+	if user.Content[1].Source.MediaType != "image/png" {
+		t.Errorf("media_type = %q, want image/png", user.Content[1].Source.MediaType)
+	}
+	if captured.MaxTokens <= 0 {
+		t.Errorf("MaxTokens = %d, want positive default", captured.MaxTokens)
+	}
+}
+
+// TestChatWithImages_DropsDetailHint asserts the bridge's Detail value
+// doesn't reach Anthropic's wire format (Anthropic doesn't accept it).
+func TestChatWithImages_DropsDetailHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		// Detail must NOT appear in the wire body.
+		if strings.Contains(string(body), `"detail"`) {
+			t.Errorf("wire body contains 'detail' key; should be dropped: %s", string(body))
+		}
+		_, _ = w.Write([]byte(`{"id":"msg","model":"claude-opus-4-5","content":[{"type":"text","text":"ok"}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{Messages: []core.Message{{Role: "user", Content: "x"}}},
+		[]core.ImageInput{{URL: "https://x/y.png", Detail: "high"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestChatWithImages_RejectsEmpty asserts the at-least-one-image guard.
+func TestChatWithImages_RejectsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			t.Error("server reached /v1/messages for empty-images request; the guard failed")
+			w.WriteHeader(500)
+			return
+		}
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{Messages: []core.Message{{Role: "user", Content: "x"}}},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("err = %v, want 'at least one' error", err)
+	}
+}
+
+// TestChatWithImages_AppendsSyntheticUserMessage asserts that with no
+// user message present, the bridge adds one to host the image blocks.
+func TestChatWithImages_AppendsSyntheticUserMessage(t *testing.T) {
+	var captured anthropicVisionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/messages") {
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		_, _ = w.Write([]byte(`{"id":"msg","model":"claude-opus-4-5","content":[{"type":"text","text":"ok"}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, err := p.ChatWithImages(context.Background(),
+		&core.ChatCompletionRequest{
+			Messages: []core.Message{{Role: "system", Content: "system only"}},
+		},
+		[]core.ImageInput{{URL: "https://x/y.png"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(captured.Messages); got != 1 {
+		t.Fatalf("messages = %d, want 1 (synthetic user)", got)
+	}
+	if captured.Messages[0].Role != "user" {
+		t.Errorf("synthetic message role = %q, want user", captured.Messages[0].Role)
+	}
+}


### PR DESCRIPTION
Tier B of #166 — Anthropic side. Closes #166 alongside Tier A (PR #192, already merged).

## What this unblocks

- \`siva\` / \`vsh\` run end-to-end against \`claude-opus-4-5\` and other vision models.
- \`h_cot\` runs end-to-end against extended-thinking models AND deterministically short-circuits to \`SkipSignatureGated\` because Anthropic signs every thinking block.

## anthropic/vision.go — Messages API content blocks

- Inline bytes → \`source.type=base64\` with \`media_type\` set from \`ImageInput.MimeType\`.
- URL refs → \`source.type=url\`.
- **Detail hint dropped on the floor** — Anthropic's API has no equivalent field. The bridge forwards Detail; this adapter ignores it. \`TestChatWithImages_DropsDetailHint\` is the regression check.
- System messages extract to top-level \`system\` field; they don't appear in the messages array.
- Images attach to the LAST user message; synthetic empty user message added if none.

## anthropic/reasoning.go — Extended thinking + signed traces

Request shape:
\`\`\`json
{
  \"model\": \"claude-opus-4-5\",
  \"max_tokens\": 14096,
  \"thinking\": {\"type\": \"enabled\", \"budget_tokens\": 10000},
  \"messages\": [...]
}
\`\`\`

Response content alternates \`thinking\` blocks (each with a \`signature\`) and \`text\` blocks. The bridge's \`signedReasoningProvider\` marker interface (introduced in Tier A) is satisfied by \`AnthropicProvider.ReasoningTraceIsSigned() bool\` returning \`true\`. Anything wrapped via \`bridge.WrapCore\` therefore surfaces \`common.ReasoningTrace.Signed=true\`.

H-CoT short-circuits to \`SkipSignatureGated\` on \`Signed=true\` — preventing wasted attempts at thinking-text mutation that the API would silently discard.

\`max_tokens\` default = \`budget_tokens + 4096\` when the operator doesn't supply one. Anthropic requires \`max_tokens >= budget_tokens\`; the +4096 leaves headroom for the response text alongside the reasoning budget.

## Acceptance criteria — all green after merge

- [x] OpenAI adapter implements both interfaces (PR #192)
- [x] Anthropic adapter implements both interfaces (this PR)
- [x] H-CoT against Anthropic emits \`OutcomeSkipped + SkipSignatureGated\` deterministically — \`ReasoningTraceIsSigned()=true\` + Tier A's bridge promotion + Tier A's \`TestWrapCore_ReasoningPromotion_SignedFlag\` integration test
- [x] H-CoT against OpenAI reasoning model returns Success / Refused / \`SkipReasoningTraceEmpty\` — Tier A
- [x] \`RUN_INTEGRATION=1 go test ./src/attacks/integration/...\` passes with mocks
- [ ] Live API round-trip tests gated on \`_API_KEY\` env vars — deferred to a follow-up that adds CI secrets and \`OPENAI_API_KEY\` / \`ANTHROPIC_API_KEY\` jobs

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 ./src/provider/anthropic/\` — 11 new tests pass
- [x] \`go test -race -count=1 ./...\` — full suite green (mirrors CI)
- [x] \`RUN_INTEGRATION=1 go test ./src/attacks/integration/\` — pass
- [x] \`bash scripts/verify-drift.sh\` — pass

CI will run \`go test -race\`. The Tier A PR taught us that any test handler that asserts on incoming requests must filter by URL path — \`NewAnthropicProvider\` kicks off an async \`GetModels\` goroutine on construction. Every handler in \`vision_test.go\` and \`reasoning_test.go\` filters on \`/v1/messages\`; \`/v1/models\` traffic gets a stub 200.