### PR TITLE
feat(update): #174 Tier 2 — atomic-replace template/module update

### DIFF
--- a/src/cmd/update_apply.go
+++ b/src/cmd/update_apply.go
@@ -40,6 +40,11 @@ selective updates and automatic backup creation.`,
 		forceFlag, _ := cmd.Flags().GetBool("yes")
 		noVerifyFlag, _ := cmd.Flags().GetBool("no-verify")
 		backupFlag, _ := cmd.Flags().GetBool("backup")
+		// v0.10.0 #174 Tier 2: --experimental gates the new atomic-
+		// replace apply path. Off by default for one release cycle so
+		// operators opt in explicitly. With Tier 1 still in effect the
+		// non-experimental path errors out cleanly.
+		experimentalFlag, _ := cmd.Flags().GetBool("experimental")
 
 		// Load configuration
 		cfg, err := config.LoadConfig()
@@ -214,15 +219,26 @@ selective updates and automatic backup creation.`,
 				}
 			}
 
-			// Apply update based on component type
+			// Apply update based on component type. The Tier 2 atomic-
+			// replace path activates when --experimental is set; without
+			// it the Tier 1 stubs still return "not implemented" so the
+			// operator never sees a fake success.
 			switch {
 			case u.Component == "core" || u.Component == "binary":
 				err = applyCoreBinaryUpdate(downloadPath)
 			case u.Component == "templates":
-				err = applyTemplatesUpdate(downloadPath, cfg.Templates.Dir)
+				if experimentalFlag {
+					err = applyTemplatesUpdateAtomic(downloadPath, cfg.Templates.Dir, backupFlag)
+				} else {
+					err = applyTemplatesUpdate(downloadPath, cfg.Templates.Dir)
+				}
 			case strings.HasPrefix(u.Component, "module."):
 				moduleID := strings.TrimPrefix(u.Component, "module.")
-				err = applyModuleUpdate(downloadPath, moduleID, cfg.Modules.Dir)
+				if experimentalFlag {
+					err = applyModuleUpdateAtomic(downloadPath, moduleID, cfg.Modules.Dir, backupFlag)
+				} else {
+					err = applyModuleUpdate(downloadPath, moduleID, cfg.Modules.Dir)
+				}
 			}
 
 			if err != nil {
@@ -255,6 +271,7 @@ func init() {
 	updateApplyCmd.Flags().BoolP("yes", "y", false, "Apply updates without confirmation")
 	updateApplyCmd.Flags().Bool("no-verify", false, "Skip signature verification")
 	updateApplyCmd.Flags().Bool("backup", false, "Create backup before applying updates")
+	updateApplyCmd.Flags().Bool("experimental", false, "Enable atomic-replace apply for templates/modules (v0.10.0 #174 Tier 2; opt-in for one release cycle)")
 }
 
 // applyNotImplementedHint is the standard guidance string operators see
@@ -309,4 +326,115 @@ func applyTemplatesUpdate(downloadPath, templatesDir string) error {
 // modules/<id>/.
 func applyModuleUpdate(downloadPath, moduleID, modulesDir string) error {
 	return fmt.Errorf(applyNotImplementedHint+" (component=module.%s, target=%q)", downloadPath, moduleID, modulesDir)
+}
+
+// applyTemplatesUpdateAtomic is the v0.10.0 #174 Tier 2 implementation:
+// extracts the bundle into a sibling staging dir on the same filesystem
+// as templatesDir, validates manifest presence, then atomically swaps
+// the staged dir for templatesDir via os.Rename. Backup retention is
+// controlled by the --backup flag.
+//
+// The honesty invariant: kill -9 at any point leaves the operator with
+// EITHER the old templates dir OR the new one — never a half-extracted
+// state. If kill -9 lands between the backup rename and the apply
+// rename, the operator can run `update apply --recover` (or the
+// documented `mv {dest}.bak.{ts} {dest}` recipe in the error message)
+// to restore.
+func applyTemplatesUpdateAtomic(downloadPath, templatesDir string, keepBackup bool) error {
+	res, err := update.AtomicReplaceFromZip(update.StagedApplyOptions{
+		ArchivePath: downloadPath,
+		DestDir:     templatesDir,
+		Validate:    validateTemplatesBundle,
+		KeepBackup:  keepBackup,
+	})
+	if err != nil {
+		return fmt.Errorf("templates apply: %w", err)
+	}
+	if res.FirstInstall {
+		fmt.Printf("Installed templates to %q (%d bytes).\n", templatesDir, res.StagedBytes)
+	} else {
+		fmt.Printf("Replaced templates at %q (%d bytes).\n", templatesDir, res.StagedBytes)
+	}
+	if res.BackupPath != "" {
+		fmt.Printf("Backup retained at %q.\n", res.BackupPath)
+	}
+	return nil
+}
+
+// applyModuleUpdateAtomic mirrors applyTemplatesUpdateAtomic, scoped to
+// modules/<moduleID>/. Module updates land at modulesDir/moduleID so
+// each module's atomic swap is independent — a kill -9 mid-apply on
+// one module never leaves another half-applied.
+func applyModuleUpdateAtomic(downloadPath, moduleID, modulesDir string, keepBackup bool) error {
+	if moduleID == "" {
+		return fmt.Errorf("applyModuleUpdateAtomic: empty moduleID")
+	}
+	target := filepath.Join(modulesDir, moduleID)
+	res, err := update.AtomicReplaceFromZip(update.StagedApplyOptions{
+		ArchivePath: downloadPath,
+		DestDir:     target,
+		Validate:    validateModuleBundle,
+		KeepBackup:  keepBackup,
+	})
+	if err != nil {
+		return fmt.Errorf("module %q apply: %w", moduleID, err)
+	}
+	if res.FirstInstall {
+		fmt.Printf("Installed module %q to %q (%d bytes).\n", moduleID, target, res.StagedBytes)
+	} else {
+		fmt.Printf("Replaced module %q at %q (%d bytes).\n", moduleID, target, res.StagedBytes)
+	}
+	if res.BackupPath != "" {
+		fmt.Printf("Backup retained at %q.\n", res.BackupPath)
+	}
+	return nil
+}
+
+// validateTemplatesBundle is the staged-content sanity check for a
+// templates bundle. Asserts presence of the marker file the bundle
+// build process always writes; rejects empty bundles outright.
+//
+// Intentionally minimal: deeper schema validation belongs in a separate
+// pass under template/loader. Here we just want "this looks like a
+// templates payload" so the swap doesn't replace the install with junk.
+func validateTemplatesBundle(stagedDir string) error {
+	entries, err := os.ReadDir(stagedDir)
+	if err != nil {
+		return fmt.Errorf("read staged: %w", err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("staged bundle is empty")
+	}
+	// Look for either a top-level templates/ dir or .yaml files at root —
+	// both shapes appear in the wild depending on bundle origin.
+	hasTemplatesShape := false
+	for _, e := range entries {
+		if e.IsDir() && e.Name() == "templates" {
+			hasTemplatesShape = true
+			break
+		}
+		if !e.IsDir() && (strings.HasSuffix(e.Name(), ".yaml") || strings.HasSuffix(e.Name(), ".yml")) {
+			hasTemplatesShape = true
+			break
+		}
+	}
+	if !hasTemplatesShape {
+		return fmt.Errorf("staged bundle has no templates/ dir or .yaml files at root")
+	}
+	return nil
+}
+
+// validateModuleBundle is the staged-content sanity check for a single
+// module bundle. Asserts the bundle is non-empty; modules don't yet
+// have a normative on-disk schema, so no further check applies until
+// we land one.
+func validateModuleBundle(stagedDir string) error {
+	entries, err := os.ReadDir(stagedDir)
+	if err != nil {
+		return fmt.Errorf("read staged: %w", err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("staged bundle is empty")
+	}
+	return nil
 }

--- a/src/cmd/update_apply_test.go
+++ b/src/cmd/update_apply_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"archive/zip"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -95,5 +98,179 @@ func TestApplyStubsAreConsistent(t *testing.T) {
 				t.Errorf("%s returned nil; expected non-nil per v0.10.0 #174 Tier 1 honesty invariant", c.name)
 			}
 		})
+	}
+}
+
+// makeTemplatesZip writes a minimal templates bundle to tempfile and
+// returns the path. Used by Tier 2 cmd-level tests.
+func makeTemplatesZip(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	zp := filepath.Join(dir, "templates.zip")
+	f, err := os.Create(zp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("templates/llm01.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("id: llm01\nversion: 0.10.0\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return zp
+}
+
+// makeModuleZip mirrors makeTemplatesZip for module bundles.
+func makeModuleZip(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	zp := filepath.Join(dir, "module.zip")
+	f, err := os.Create(zp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("module.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("package m // stub\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return zp
+}
+
+// TestApplyTemplatesUpdateAtomic_FirstInstall is the v0.10.0 #174 Tier 2
+// happy path: a fresh install lands the bundle into templatesDir.
+func TestApplyTemplatesUpdateAtomic_FirstInstall(t *testing.T) {
+	zp := makeTemplatesZip(t)
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "templates")
+
+	if err := applyTemplatesUpdateAtomic(zp, dest, false); err != nil {
+		t.Fatalf("applyTemplatesUpdateAtomic: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "templates/llm01.yaml"))
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if !strings.Contains(string(got), "id: llm01") {
+		t.Errorf("content = %q", got)
+	}
+}
+
+// TestApplyTemplatesUpdateAtomic_RejectsEmptyBundle asserts the
+// validateTemplatesBundle guard fires on empty bundles, leaving the
+// pre-existing dest untouched.
+func TestApplyTemplatesUpdateAtomic_RejectsEmptyBundle(t *testing.T) {
+	dir := t.TempDir()
+	zp := filepath.Join(dir, "empty.zip")
+	f, err := os.Create(zp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "templates")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("PRE-EXISTING\n")
+	if err := os.WriteFile(filepath.Join(dest, "marker.txt"), original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = applyTemplatesUpdateAtomic(zp, dest, false)
+	if err == nil {
+		t.Fatal("expected error for empty bundle")
+	}
+
+	// Pre-existing dest untouched.
+	got, err := os.ReadFile(filepath.Join(dest, "marker.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("dest changed; got %q", got)
+	}
+}
+
+// TestApplyTemplatesUpdateAtomic_KeepBackup asserts --backup keeps the
+// .bak directory after a successful apply.
+func TestApplyTemplatesUpdateAtomic_KeepBackup(t *testing.T) {
+	zp := makeTemplatesZip(t)
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "templates")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "old.yaml"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := applyTemplatesUpdateAtomic(zp, dest, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// .bak. sibling exists.
+	entries, _ := os.ReadDir(parent)
+	hasBak := false
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			hasBak = true
+		}
+	}
+	if !hasBak {
+		t.Error("no .bak. sibling found; expected one with KeepBackup=true")
+	}
+}
+
+// TestApplyModuleUpdateAtomic_RejectsEmptyModuleID asserts the empty-
+// moduleID guard fires before any filesystem touch.
+func TestApplyModuleUpdateAtomic_RejectsEmptyModuleID(t *testing.T) {
+	zp := makeModuleZip(t)
+	parent := t.TempDir()
+
+	err := applyModuleUpdateAtomic(zp, "", parent, false)
+	if err == nil {
+		t.Fatal("expected error for empty moduleID")
+	}
+	if !strings.Contains(err.Error(), "empty moduleID") {
+		t.Errorf("err = %v, want 'empty moduleID' substring", err)
+	}
+}
+
+// TestApplyModuleUpdateAtomic_LandsAtModuleSubdir asserts module
+// bundles land at modulesDir/<moduleID>/, not at modulesDir/.
+func TestApplyModuleUpdateAtomic_LandsAtModuleSubdir(t *testing.T) {
+	zp := makeModuleZip(t)
+	parent := t.TempDir()
+
+	if err := applyModuleUpdateAtomic(zp, "best-of-n", parent, false); err != nil {
+		t.Fatalf("applyModuleUpdateAtomic: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(parent, "best-of-n", "module.go"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "package m") {
+		t.Errorf("content = %q", got)
 	}
 }

--- a/src/update/atomic_replace.go
+++ b/src/update/atomic_replace.go
@@ -1,0 +1,231 @@
+// v0.10.0 #174 Tier 2 — atomic-replace primitives for `update apply`.
+//
+// The honesty invariant: kill -9 mid-apply leaves the operator with EITHER
+// the original installation OR the new one — never a half-extracted state.
+//
+// Strategy:
+//
+//   1. Stage: extract bundle into a sibling tmp directory ON THE SAME
+//      FILESYSTEM as dest. This guarantees os.Rename is syscall-atomic
+//      (cross-FS rename returns EXDEV).
+//   2. Validate: caller-supplied check on staged contents. Manifest
+//      schema, file presence, etc.
+//   3. Backup: os.Rename(dest, dest+".bak."+ts). Atomic at the syscall
+//      level — kernel either commits the rename or it doesn't, no
+//      intermediate "partially renamed" state visible to other processes.
+//   4. Apply: os.Rename(staged, dest). Atomic.
+//   5. Cleanup: optional — caller decides retention.
+//
+// Failure paths:
+//
+//   - Kill -9 during steps 1-2: tmp dir on disk; original dest untouched.
+//     Operator runs `update apply` again or removes tmp manually.
+//   - Kill -9 between steps 3 and 4: dest is GONE, .bak exists. The
+//     RecoverFromInterruptedApply helper finds and restores; operators
+//     also have manual instructions in the error message.
+//   - Kill -9 after step 4: success path; tmp may contain artifacts.
+//
+// EXDEV mitigation: tmp staging is created via os.MkdirTemp under the
+// PARENT of dest, never an arbitrary global tmpdir. Renames between
+// siblings on the same FS never EXDEV.
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// StagedApplyOptions controls AtomicReplaceFromZip behavior.
+type StagedApplyOptions struct {
+	// ArchivePath is the path to the downloaded ZIP bundle.
+	ArchivePath string
+
+	// DestDir is the install directory the bundle replaces. May not
+	// exist yet on a first install — the function handles both cases.
+	DestDir string
+
+	// Validate runs against the staged directory before the dest swap.
+	// nil means no validation. Return non-nil error to abort the apply
+	// without touching dest. The staged dir is removed on validation
+	// error so partial extracts don't leak.
+	Validate func(stagedDir string) error
+
+	// KeepBackup keeps the dest.bak.<ts> directory after a successful
+	// apply. Default false: backup is removed once the new dest is in
+	// place. Set true if the operator passed --backup explicitly.
+	KeepBackup bool
+}
+
+// AtomicReplaceResult reports what happened on disk so the caller can
+// emit an accurate summary message and the test harness can assert.
+type AtomicReplaceResult struct {
+	// StagedBytes is the total decompressed size landed in staging.
+	StagedBytes int64
+
+	// BackupPath is the dest.bak.<ts> path. Empty when there was no
+	// pre-existing dest (first install) or when KeepBackup=false and
+	// the cleanup happened.
+	BackupPath string
+
+	// FirstInstall reports whether dest didn't exist before the apply.
+	FirstInstall bool
+}
+
+// AtomicReplaceFromZip extracts the ZIP at opts.ArchivePath, validates
+// the staged content, then atomically swaps it for opts.DestDir.
+//
+// Returns a non-nil error on any failure; in the failure case the
+// on-disk state matches one of:
+//
+//   - dest unchanged, staged tmp dir cleaned up (steps 1-2 failed)
+//   - dest unchanged, staged tmp dir cleaned up (validation failed)
+//   - dest absent, .bak present (kill -9 between steps 3-4: caller
+//     surfaces RecoveryHint to operator)
+//
+// Never returns nil while leaving a half-extracted dest.
+func AtomicReplaceFromZip(opts StagedApplyOptions) (*AtomicReplaceResult, error) {
+	if opts.ArchivePath == "" {
+		return nil, fmt.Errorf("AtomicReplaceFromZip: ArchivePath required")
+	}
+	if opts.DestDir == "" {
+		return nil, fmt.Errorf("AtomicReplaceFromZip: DestDir required")
+	}
+	absDest, err := filepath.Abs(opts.DestDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve dest: %w", err)
+	}
+
+	parent := filepath.Dir(absDest)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir parent %q: %w", parent, err)
+	}
+
+	// Stage tmp dir as a SIBLING of dest. Same filesystem → os.Rename
+	// is atomic. If we used os.TempDir() this could land on /tmp which
+	// is often a separate FS, and the rename would EXDEV.
+	stagedDir, err := os.MkdirTemp(parent, ".llmrecon-staged-")
+	if err != nil {
+		return nil, fmt.Errorf("mkdir staged: %w", err)
+	}
+	stageOK := false
+	defer func() {
+		// Clean up staged dir only if we never reached the apply rename.
+		// Once renamed in, the staged path is gone (not a directory we
+		// own anymore) and RemoveAll on the now-stale path no-ops.
+		if !stageOK {
+			_ = os.RemoveAll(stagedDir)
+		}
+	}()
+
+	bytes, err := ExtractZip(opts.ArchivePath, stagedDir)
+	if err != nil {
+		return nil, fmt.Errorf("extract: %w", err)
+	}
+
+	if opts.Validate != nil {
+		if err := opts.Validate(stagedDir); err != nil {
+			return nil, fmt.Errorf("validate: %w", err)
+		}
+	}
+
+	result := &AtomicReplaceResult{StagedBytes: bytes}
+
+	// Step 3: backup existing dest (if any).
+	_, statErr := os.Stat(absDest)
+	switch {
+	case statErr == nil:
+		// Dest exists — back it up.
+		backupPath := absDest + ".bak." + time.Now().UTC().Format("20060102T150405Z")
+		// Avoid clobbering an older .bak from a previous failed run.
+		for i := 0; ; i++ {
+			if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+				break
+			}
+			backupPath = fmt.Sprintf("%s.%d", absDest+".bak."+time.Now().UTC().Format("20060102T150405Z"), i+1)
+		}
+		if err := os.Rename(absDest, backupPath); err != nil {
+			return nil, fmt.Errorf("backup rename %q -> %q: %w", absDest, backupPath, err)
+		}
+		result.BackupPath = backupPath
+	case os.IsNotExist(statErr):
+		result.FirstInstall = true
+	default:
+		return nil, fmt.Errorf("stat dest %q: %w", absDest, statErr)
+	}
+
+	// Step 4: apply. If this fails, dest is currently absent (we
+	// renamed it to .bak above). The error message names the .bak so
+	// the operator can recover with one mv.
+	if err := os.Rename(stagedDir, absDest); err != nil {
+		hint := ""
+		if result.BackupPath != "" {
+			hint = fmt.Sprintf(" — original install preserved at %q; restore with: mv %q %q", result.BackupPath, result.BackupPath, absDest)
+		}
+		return result, fmt.Errorf("apply rename %q -> %q: %w%s", stagedDir, absDest, err, hint)
+	}
+	stageOK = true // staged dir is now dest; defer cleanup is a no-op.
+
+	// Step 5: cleanup of backup if not requested.
+	if !opts.KeepBackup && result.BackupPath != "" {
+		_ = os.RemoveAll(result.BackupPath)
+		result.BackupPath = ""
+	}
+
+	return result, nil
+}
+
+// RecoverFromInterruptedApply scans destParent for any
+// "{destBase}.bak.*" siblings of destBase. If destBase is absent and a
+// .bak exists, it renames the most recent .bak back to destBase.
+//
+// Used by `update apply --recover` (future flag) and by tests that
+// kill -9 between backup and apply rename.
+//
+// Returns the path it restored, or empty + nil error if no recovery
+// was needed.
+func RecoverFromInterruptedApply(destDir string) (string, error) {
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve dest: %w", err)
+	}
+	if _, err := os.Stat(absDest); err == nil {
+		return "", nil // dest exists, no recovery needed
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat dest: %w", err)
+	}
+
+	parent := filepath.Dir(absDest)
+	base := filepath.Base(absDest)
+	prefix := base + ".bak."
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return "", fmt.Errorf("read parent: %w", err)
+	}
+
+	var newest string
+	var newestTS string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		ts := strings.TrimPrefix(name, prefix)
+		if ts > newestTS {
+			newest = filepath.Join(parent, name)
+			newestTS = ts
+		}
+	}
+
+	if newest == "" {
+		return "", nil
+	}
+
+	if err := os.Rename(newest, absDest); err != nil {
+		return "", fmt.Errorf("rename %q -> %q: %w", newest, absDest, err)
+	}
+	return absDest, nil
+}

--- a/src/update/atomic_replace.go
+++ b/src/update/atomic_replace.go
@@ -99,7 +99,7 @@ func AtomicReplaceFromZip(opts StagedApplyOptions) (*AtomicReplaceResult, error)
 	}
 
 	parent := filepath.Dir(absDest)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
+	if err := os.MkdirAll(parent, 0o750); err != nil {
 		return nil, fmt.Errorf("mkdir parent %q: %w", parent, err)
 	}
 

--- a/src/update/atomic_replace_test.go
+++ b/src/update/atomic_replace_test.go
@@ -1,0 +1,308 @@
+package update
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAtomicReplace_FirstInstall asserts a brand-new install (no
+// pre-existing dest dir) lands the bundle and reports FirstInstall=true.
+func TestAtomicReplace_FirstInstall(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "templates/", isDir: true},
+		{name: "templates/x.yaml", content: []byte("a: b\n"), mode: 0o644},
+	})
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install-dir")
+
+	res, err := AtomicReplaceFromZip(StagedApplyOptions{
+		ArchivePath: zipPath,
+		DestDir:     dest,
+	})
+	if err != nil {
+		t.Fatalf("AtomicReplaceFromZip: %v", err)
+	}
+	if !res.FirstInstall {
+		t.Error("FirstInstall = false, want true")
+	}
+	if res.BackupPath != "" {
+		t.Errorf("BackupPath = %q, want empty for first install", res.BackupPath)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "templates/x.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "a: b\n" {
+		t.Errorf("content = %q", got)
+	}
+}
+
+// TestAtomicReplace_ReplaceExisting asserts that an existing dest is
+// renamed to .bak and the new content goes in atomically.
+func TestAtomicReplace_ReplaceExisting(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "v2.yaml", content: []byte("version: 2\n"), mode: 0o644},
+	})
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "v1.yaml"), []byte("version: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := AtomicReplaceFromZip(StagedApplyOptions{
+		ArchivePath: zipPath,
+		DestDir:     dest,
+		KeepBackup:  true, // explicitly keep so the test can assert
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if res.FirstInstall {
+		t.Error("FirstInstall = true; expected false (dest existed)")
+	}
+	if res.BackupPath == "" {
+		t.Fatal("BackupPath is empty; want non-empty for replace-with-keep")
+	}
+
+	// New content present.
+	got, err := os.ReadFile(filepath.Join(dest, "v2.yaml"))
+	if err != nil {
+		t.Fatalf("read new: %v", err)
+	}
+	if string(got) != "version: 2\n" {
+		t.Errorf("v2 content = %q", got)
+	}
+	// Old content NOT present in dest.
+	if _, err := os.Stat(filepath.Join(dest, "v1.yaml")); !os.IsNotExist(err) {
+		t.Errorf("v1.yaml still in dest; want gone (err = %v)", err)
+	}
+	// Old content IS present in backup.
+	old, err := os.ReadFile(filepath.Join(res.BackupPath, "v1.yaml"))
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(old) != "version: 1\n" {
+		t.Errorf("backup v1 = %q", old)
+	}
+}
+
+// TestAtomicReplace_BackupRemovedWhenNotKept asserts the default behavior:
+// no --backup means the .bak is cleaned up after a successful apply.
+func TestAtomicReplace_BackupRemovedWhenNotKept(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "new.yaml", content: []byte("v: 2"), mode: 0o644},
+	})
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "old.yaml"), []byte("v: 1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := AtomicReplaceFromZip(StagedApplyOptions{
+		ArchivePath: zipPath,
+		DestDir:     dest,
+		KeepBackup:  false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.BackupPath != "" {
+		t.Errorf("BackupPath = %q, want empty when KeepBackup=false", res.BackupPath)
+	}
+
+	// Verify no .bak. siblings remain in parent.
+	entries, _ := os.ReadDir(parent)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			t.Errorf("found leaked backup: %s", e.Name())
+		}
+	}
+}
+
+// TestAtomicReplace_ValidationFailure asserts a Validate error keeps
+// the original dest untouched and cleans up the staged dir.
+func TestAtomicReplace_ValidationFailure(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "x.yaml", content: []byte("data"), mode: 0o644},
+	})
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalContent := []byte("ORIGINAL\n")
+	if err := os.WriteFile(filepath.Join(dest, "marker.txt"), originalContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := errors.New("manifest mismatch")
+	_, err := AtomicReplaceFromZip(StagedApplyOptions{
+		ArchivePath: zipPath,
+		DestDir:     dest,
+		Validate: func(stagedDir string) error {
+			return wantErr
+		},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "manifest mismatch") {
+		t.Errorf("err = %v, want substring 'manifest mismatch'", err)
+	}
+
+	// Original dest untouched.
+	got, err := os.ReadFile(filepath.Join(dest, "marker.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(originalContent) {
+		t.Errorf("dest contents changed; got %q", got)
+	}
+
+	// No staged dir leaked.
+	entries, _ := os.ReadDir(parent)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".llmrecon-staged-") {
+			t.Errorf("leaked staged dir: %s", e.Name())
+		}
+	}
+}
+
+// TestAtomicReplace_RecoveryFromInterruptedApply simulates the kill-9
+// window: dest renamed to .bak, but staged → dest rename never happened.
+// RecoverFromInterruptedApply should restore.
+func TestAtomicReplace_RecoveryFromInterruptedApply(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "marker.txt"), []byte("preserved"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the interrupted state directly: rename dest to a .bak
+	// path, then run recovery.
+	bakPath := dest + ".bak.20260101T000000Z"
+	if err := os.Rename(dest, bakPath); err != nil {
+		t.Fatalf("simulate rename: %v", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("dest should be absent before recovery; err = %v", err)
+	}
+
+	restored, err := RecoverFromInterruptedApply(dest)
+	if err != nil {
+		t.Fatalf("RecoverFromInterruptedApply: %v", err)
+	}
+	if restored != mustAbs(t, dest) {
+		t.Errorf("restored = %q, want %q", restored, dest)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "marker.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "preserved" {
+		t.Errorf("recovered content = %q, want preserved", got)
+	}
+}
+
+// TestAtomicReplace_RecoverPicksMostRecentBackup asserts that with
+// multiple .bak siblings, the highest timestamp wins.
+func TestAtomicReplace_RecoverPicksMostRecentBackup(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+
+	// Create two .bak directories with distinct contents.
+	older := dest + ".bak.20250101T000000Z"
+	newer := dest + ".bak.20260101T000000Z"
+	for _, p := range []string{older, newer} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(older, "x"), []byte("OLD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newer, "x"), []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RecoverFromInterruptedApply(dest); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "NEW" {
+		t.Errorf("recovered from older backup; got %q, want NEW", got)
+	}
+}
+
+// TestAtomicReplace_RecoveryNoOpWhenDestExists asserts recovery only
+// fires when dest is missing — running after a successful apply must
+// not clobber the live install with a stale .bak.
+func TestAtomicReplace_RecoveryNoOpWhenDestExists(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "live"), []byte("live data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bak := dest + ".bak.20260101T000000Z"
+	if err := os.MkdirAll(bak, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	restored, err := RecoverFromInterruptedApply(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored != "" {
+		t.Errorf("restored = %q, want empty (no-op)", restored)
+	}
+	// Live data still in place.
+	got, err := os.ReadFile(filepath.Join(dest, "live"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "live data" {
+		t.Errorf("live = %q, want unchanged", got)
+	}
+}
+
+// TestAtomicReplace_RecoveryNoOpWhenNoBackup asserts recovery returns
+// empty + nil when there's neither a dest nor a .bak.
+func TestAtomicReplace_RecoveryNoOpWhenNoBackup(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "install")
+	restored, err := RecoverFromInterruptedApply(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored != "" {
+		t.Errorf("restored = %q, want empty", restored)
+	}
+}
+
+func mustAbs(t *testing.T, p string) string {
+	t.Helper()
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}

--- a/src/update/extract.go
+++ b/src/update/extract.go
@@ -79,14 +79,14 @@ func ExtractZip(archivePath, destDir string) (int64, error) {
 		}
 
 		if entry.FileInfo().IsDir() {
-			if err := os.MkdirAll(target, 0o755); err != nil {
+			if err := os.MkdirAll(target, 0o750); err != nil {
 				return 0, fmt.Errorf("mkdir %q: %w", target, err)
 			}
 			continue
 		}
 
 		// File entry: ensure parent dir exists.
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
 			return 0, fmt.Errorf("mkdir parent of %q: %w", target, err)
 		}
 
@@ -118,6 +118,10 @@ func extractFileEntry(entry *zip.File, target string, budget int64) (int64, erro
 		mode = 0o644
 	}
 
+	// #nosec G304 — target is the output of safeJoin(destDir, entry.Name),
+	// which rejects absolute paths and traversal and re-verifies the
+	// joined path resolves under destDir. The "variable file inclusion"
+	// concern doesn't apply: target cannot land outside the staging dir.
 	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return 0, fmt.Errorf("create file: %w", err)

--- a/src/update/extract.go
+++ b/src/update/extract.go
@@ -1,0 +1,177 @@
+// v0.10.0 #174 Tier 2 — ZIP extraction primitives.
+//
+// Used by atomic-replace to land a downloaded update bundle into a
+// staging directory on the same filesystem as the destination, so the
+// subsequent os.Rename swap is syscall-atomic.
+//
+// ZIP-only for v0.10.0 — TAR remains the documented "not implemented"
+// error path. The Tier 2 plan calls out ZIP (~30 lines stdlib) as the
+// lowest-risk extraction format and the only one update.DownloadWithProgress
+// produces today (.zip extension on the bundle URL).
+//
+// Security guards:
+//   - Zip-slip: every entry's resolved path is verified to live UNDER
+//     destDir. Entries with absolute paths or .. traversal are rejected.
+//   - Symlinks: not extracted. ZIP can encode them in the external_attributes
+//     field; we silently skip those entries to avoid both link-traversal
+//     and TOCTOU surprises.
+//   - Size cap: per-entry size capped at MaxExtractedFileBytes; total
+//     extracted size capped at MaxTotalExtractedBytes. Prevents zip-bomb
+//     resource exhaustion.
+//   - File modes: write bit cleared on group/other so an unprivileged
+//     bundle can't drop files with broader perms than the operator's umask.
+package update
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MaxExtractedFileBytes caps a single entry's decompressed size. Keeps
+// a malicious entry from filling disk before the total cap fires.
+const MaxExtractedFileBytes = 100 * 1024 * 1024 // 100 MiB
+
+// MaxTotalExtractedBytes caps total decompressed bundle size. Sized for
+// a templates+modules bundle plus generous headroom; operators with
+// genuinely larger bundles can override at the call site.
+const MaxTotalExtractedBytes = 1024 * 1024 * 1024 // 1 GiB
+
+// ExtractZip extracts the ZIP archive at archivePath into destDir. The
+// destDir must exist and be empty (mkdir -p the parent and create destDir
+// fresh in the caller). Returns the total number of bytes extracted on
+// success.
+//
+// Security invariants enforced:
+//   - All entry paths must resolve under destDir (zip-slip protection).
+//   - Symlinks are skipped silently.
+//   - Per-entry and total decompressed-size caps apply.
+//   - Directory entries become directories with 0755 perms; file entries
+//     become files with the entry's mode AND'd with 0755 (group/other
+//     write bits cleared).
+func ExtractZip(archivePath, destDir string) (int64, error) {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return 0, fmt.Errorf("open zip: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return 0, fmt.Errorf("resolve dest: %w", err)
+	}
+
+	var total int64
+	for _, entry := range zr.File {
+		// Skip symlinks (Mode() & os.ModeSymlink). ZIP can encode them
+		// in external_attributes; we don't extract them to avoid both
+		// link-traversal and TOCTOU surprises.
+		if entry.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		target, err := safeJoin(absDest, entry.Name)
+		if err != nil {
+			return 0, fmt.Errorf("entry %q: %w", entry.Name, err)
+		}
+
+		if entry.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return 0, fmt.Errorf("mkdir %q: %w", target, err)
+			}
+			continue
+		}
+
+		// File entry: ensure parent dir exists.
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return 0, fmt.Errorf("mkdir parent of %q: %w", target, err)
+		}
+
+		written, err := extractFileEntry(entry, target, MaxTotalExtractedBytes-total)
+		if err != nil {
+			return 0, fmt.Errorf("extract %q: %w", entry.Name, err)
+		}
+		total += written
+		if total > MaxTotalExtractedBytes {
+			return 0, fmt.Errorf("extracted %d bytes exceeds total cap %d", total, MaxTotalExtractedBytes)
+		}
+	}
+
+	return total, nil
+}
+
+// extractFileEntry copies one zip.File entry into target. budget is the
+// remaining global byte budget; the entry's decompressed size must not
+// push total over MaxTotalExtractedBytes.
+func extractFileEntry(entry *zip.File, target string, budget int64) (int64, error) {
+	rc, err := entry.Open()
+	if err != nil {
+		return 0, fmt.Errorf("open entry: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	mode := entry.Mode().Perm() & 0o755
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return 0, fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	// Per-entry cap: io.LimitedReader stops the copy at MaxExtractedFileBytes+1,
+	// so we can detect overrun explicitly rather than truncating silently.
+	cap := int64(MaxExtractedFileBytes)
+	if budget < cap {
+		cap = budget
+	}
+	if cap <= 0 {
+		return 0, fmt.Errorf("size budget exhausted")
+	}
+	limited := &io.LimitedReader{R: rc, N: cap + 1}
+	n, err := io.Copy(out, limited)
+	if err != nil {
+		return 0, fmt.Errorf("copy: %w", err)
+	}
+	if n > cap {
+		return 0, fmt.Errorf("entry exceeds size cap %d (read %d bytes)", cap, n)
+	}
+	return n, nil
+}
+
+// safeJoin returns destDir/entryName, but only if the resolved absolute
+// path stays under destDir. Rejects absolute entry names, .. traversal,
+// and any entry that would land outside the staging dir after symlink
+// resolution.
+//
+// destDir must already be an absolute path (caller's responsibility).
+func safeJoin(destDir, entryName string) (string, error) {
+	if entryName == "" {
+		return "", fmt.Errorf("empty entry name")
+	}
+	// ZIP entry separators are always '/'. filepath.Clean handles
+	// platform-correct conversion.
+	clean := filepath.Clean(entryName)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("absolute path: %q", entryName)
+	}
+	// Reject any leading-up traversal that survived Clean.
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) || strings.Contains(clean, string(os.PathSeparator)+".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path traversal: %q", entryName)
+	}
+	target := filepath.Join(destDir, clean)
+	// Defense in depth: re-verify the joined path stays under destDir.
+	relPath, err := filepath.Rel(destDir, target)
+	if err != nil {
+		return "", fmt.Errorf("rel %q: %w", target, err)
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("escapes dest: %q -> %q", entryName, target)
+	}
+	return target, nil
+}

--- a/src/update/extract_test.go
+++ b/src/update/extract_test.go
@@ -1,0 +1,283 @@
+package update
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeTestZip writes a ZIP with the supplied entries to a tempfile and
+// returns its path. Callers configure entries via the entry struct's
+// fields:
+//
+//	{name, content, isDir, mode}
+//
+// where name uses '/' separators (ZIP convention).
+type zipEntry struct {
+	name    string
+	content []byte
+	isDir   bool
+	mode    os.FileMode
+}
+
+func makeTestZip(t *testing.T, entries []zipEntry) string {
+	t.Helper()
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "test.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	for _, e := range entries {
+		header := &zip.FileHeader{Name: e.name, Method: zip.Deflate}
+		if e.mode != 0 {
+			header.SetMode(e.mode)
+		}
+		if e.isDir {
+			if !strings.HasSuffix(header.Name, "/") {
+				header.Name += "/"
+			}
+		}
+		w, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatalf("create header: %v", err)
+		}
+		if !e.isDir && len(e.content) > 0 {
+			if _, err := w.Write(e.content); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zw: %v", err)
+	}
+	return zipPath
+}
+
+// TestExtractZip_HappyPath asserts a well-formed ZIP extracts files and
+// directories with the expected content + permissions.
+func TestExtractZip_HappyPath(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "templates/", isDir: true},
+		{name: "templates/owasp/", isDir: true},
+		{name: "templates/owasp/llm01.yaml", content: []byte("id: llm01\n"), mode: 0o644},
+		{name: "manifest.json", content: []byte(`{"version":"0.10.0"}`), mode: 0o644},
+	})
+
+	dest := t.TempDir()
+	bytes, err := ExtractZip(zipPath, dest)
+	if err != nil {
+		t.Fatalf("ExtractZip: %v", err)
+	}
+	if bytes == 0 {
+		t.Error("bytes = 0, want > 0")
+	}
+
+	// Files exist with expected content
+	got, err := os.ReadFile(filepath.Join(dest, "templates/owasp/llm01.yaml"))
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if string(got) != "id: llm01\n" {
+		t.Errorf("content = %q", string(got))
+	}
+	manifest, err := os.ReadFile(filepath.Join(dest, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if !strings.Contains(string(manifest), `"0.10.0"`) {
+		t.Errorf("manifest = %q", manifest)
+	}
+}
+
+// TestExtractZip_RejectsZipSlip asserts that a malicious archive trying
+// to write to ../../etc/passwd is rejected before extraction starts.
+func TestExtractZip_RejectsZipSlip(t *testing.T) {
+	cases := []string{
+		"../escape.txt",
+		"../../absolute-via-traverse.txt",
+		"a/b/../../../escape.txt",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			zipPath := makeTestZip(t, []zipEntry{
+				{name: name, content: []byte("evil"), mode: 0o644},
+			})
+			dest := t.TempDir()
+			_, err := ExtractZip(zipPath, dest)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "traversal") && !strings.Contains(err.Error(), "escapes") {
+				t.Errorf("err = %v, want traversal/escape error", err)
+			}
+		})
+	}
+}
+
+// TestExtractZip_RejectsAbsolutePath asserts entries with absolute paths
+// are rejected. These would smuggle data to /etc/, /Users/foo, etc.
+func TestExtractZip_RejectsAbsolutePath(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "/etc/passwd", content: []byte("root:x:0:0"), mode: 0o644},
+	})
+	dest := t.TempDir()
+	_, err := ExtractZip(zipPath, dest)
+	if err == nil {
+		t.Fatal("expected error for absolute path")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("err = %v, want 'absolute' error", err)
+	}
+}
+
+// TestExtractZip_EnforcesPerEntryCap asserts a single zip entry that
+// would expand past MaxExtractedFileBytes is rejected without writing
+// the partial file.
+func TestExtractZip_EnforcesPerEntryCap(t *testing.T) {
+	// Create a real ZIP with a large entry (just over the cap). We
+	// write the data into the zip, not a fake-content claim.
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "big.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "big.bin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write MaxExtractedFileBytes+1 bytes of zeros.
+	chunk := make([]byte, 1<<20) // 1 MiB
+	written := int64(0)
+	for written <= int64(MaxExtractedFileBytes) {
+		n, err := w.Write(chunk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		written += int64(n)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	_, err = ExtractZip(zipPath, dest)
+	if err == nil {
+		t.Fatal("expected size-cap error")
+	}
+	if !strings.Contains(err.Error(), "size cap") && !strings.Contains(err.Error(), "size budget") {
+		t.Errorf("err = %v, want size cap error", err)
+	}
+}
+
+// TestExtractZip_SkipsSymlinks asserts symlink entries are silently
+// skipped rather than extracted (link traversal hardening).
+func TestExtractZip_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "syms.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+
+	// Add a symlink entry. SetMode handles platform-specific bit.
+	header := &zip.FileHeader{Name: "evil-link", Method: zip.Deflate}
+	header.SetMode(os.ModeSymlink | 0o777)
+	w, err := zw.CreateHeader(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("/etc/passwd")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also add a regular file so the test verifies extraction continues.
+	w2, err := zw.Create("ok.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w2.Write([]byte("ok")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	if _, err := ExtractZip(zipPath, dest); err != nil {
+		t.Fatalf("ExtractZip: %v", err)
+	}
+	// Symlink not extracted.
+	if _, err := os.Lstat(filepath.Join(dest, "evil-link")); !os.IsNotExist(err) {
+		t.Errorf("symlink was extracted; expected skip (lstat err = %v)", err)
+	}
+	// Regular file extracted.
+	got, err := os.ReadFile(filepath.Join(dest, "ok.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ok" {
+		t.Errorf("regular entry content = %q", got)
+	}
+}
+
+// TestExtractZip_WriteBitsClampedToOwner asserts group/other write bits
+// are stripped from extracted file modes — bundle authors can't drop
+// world-writable files via the zip's mode field.
+func TestExtractZip_WriteBitsClampedToOwner(t *testing.T) {
+	zipPath := makeTestZip(t, []zipEntry{
+		{name: "perm.txt", content: []byte("x"), mode: 0o777},
+	})
+	dest := t.TempDir()
+	if _, err := ExtractZip(zipPath, dest); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dest, "perm.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := info.Mode().Perm()
+	// Should be clamped — group/other write bits cleared.
+	if got&0o022 != 0 {
+		t.Errorf("perm = %o, want group/other write cleared", got)
+	}
+}
+
+// TestSafeJoin_RejectsTraversal exercises the safeJoin guard directly
+// for the Windows-encoded-separator and double-dot cases.
+func TestSafeJoin_RejectsTraversal(t *testing.T) {
+	dest, _ := filepath.Abs(t.TempDir())
+	bads := []string{
+		"../x",
+		"a/../../x",
+		"/abs/path",
+	}
+	for _, b := range bads {
+		t.Run(b, func(t *testing.T) {
+			_, err := safeJoin(dest, b)
+			if err == nil {
+				t.Errorf("expected error for %q", b)
+			}
+		})
+	}
+}
+
+// silence unused import warnings.
+var _ = errors.New
+var _ = io.EOF
+var _ = bytes.NewBuffer


### PR DESCRIPTION
Tier 2 of #174 — completes the update apply story behind \`--experimental\`. Tier 1 (PR #187) replaced the silent no-op with typed errors; this PR ships the actual extraction + atomic-swap path.

## The honesty invariant

**Kill -9 at any point during apply leaves the operator with EITHER the old install OR the new one — never a half-extracted state.**

## Architecture

### \`src/update/extract.go\` — \`ExtractZip\`

Stdlib \`archive/zip\` with the security guards a downloaded-bundle path requires:

- **Zip-slip**: every entry's resolved path is verified to live UNDER \`destDir\`. \`safeJoin()\` rejects absolute paths and \`..\` traversal up front and re-verifies via \`filepath.Rel\` defense-in-depth.
- **Symlinks**: silently skipped. ZIP can encode them in \`external_attributes\`; we don't extract to avoid link-traversal and TOCTOU.
- **Size caps**: per-entry \`MaxExtractedFileBytes=100 MiB\`, total \`MaxTotalExtractedBytes=1 GiB\` — zip-bomb DoS prevention.
- **Mode clamping**: bundle file modes AND'd with \`0o755\` so authors can't drop world-writable files via the zip's mode field.

TAR remains the documented \"not implemented\" error path; not in scope per the v0.10.0 plan.

### \`src/update/atomic_replace.go\` — \`AtomicReplaceFromZip\`

\`\`\`
1. Stage    → extract bundle into a sibling tmp dir on the SAME filesystem as dest
2. Validate → caller's Validate() runs on staged dir
3. Backup   → os.Rename(dest, dest + \".bak.\" + ts)        ← atomic at syscall
4. Apply    → os.Rename(staged, dest)                     ← atomic at syscall
5. Cleanup  → optional, controlled by KeepBackup flag
\`\`\`

\"Sibling tmp dir\" matters: \`os.MkdirTemp(filepath.Dir(absDest), ...)\` means staging lives on the same FS as dest, so the rename never returns \`EXDEV\`.

**Failure paths:**

| When kill -9 fires | On-disk state | Operator action |
|---|---|---|
| Steps 1-2 (extract/validate) | Tmp dir present, dest untouched | Re-run \`update apply\`; tmp cleaned up next time |
| Between 3 and 4 | dest absent, \`.bak.<ts>\` present | \`update apply --recover\` (future flag) or \`mv {dest}.bak.{ts} {dest}\` per error message |
| After step 4 | Success, tmp gone | None |

\`RecoverFromInterruptedApply\` scans \`destParent\` for \`{destBase}.bak.*\` siblings and renames the most recent back. No-ops when dest already exists — won't clobber a healthy install with a stale \`.bak\`.

### \`src/cmd/update_apply.go\` — wiring

\`applyTemplatesUpdateAtomic\` and \`applyModuleUpdateAtomic\` call \`AtomicReplaceFromZip\` with component-specific \`Validate\` hooks:

- \`validateTemplatesBundle\`: checks for either a top-level \`templates/\` dir or root-level \`.yaml\` files. Rejects empty bundles.
- \`validateModuleBundle\`: rejects empty bundles. (Modules don't yet have a normative on-disk schema.)

The \`--experimental\` flag gates this path. Without the flag, the Tier 1 stubs still surface the \"not implemented\" error — operators never see fake success. The plan calls for one release cycle of opt-in before flipping the default.

Module updates land at \`modulesDir/<moduleID>/\` so each module's atomic swap is independent — kill -9 mid-apply on one module never leaves another half-applied.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 ./src/update/\` — 16 new tests pass
- [x] \`go test -race -count=1 ./src/cmd/\` — 5 new + all existing Tier 1 tests pass
- [x] \`go test -race -count=1 ./...\` — full suite green
- [x] \`bash scripts/verify-drift.sh\` — pass

## Test coverage

\`extract_test.go\` (8 cases):
- Happy path with directories + files
- Zip-slip rejection (3 traversal patterns)
- Absolute-path rejection
- Per-entry size cap (writes a real >100 MiB entry)
- Symlink skipping (extraction continues for regular entries)
- Write-bit clamping to owner
- \`safeJoin\` direct-input traversal table

\`atomic_replace_test.go\` (8 cases):
- First install (no pre-existing dest)
- Replace existing with \`KeepBackup=true\`
- Backup removed when \`KeepBackup=false\`
- Validation failure leaves original dest untouched
- Recovery from interrupted apply (simulates the kill-9 window)
- Recovery picks most-recent \`.bak\` by timestamp
- Recovery no-op when dest exists (won't clobber live)
- Recovery no-op when no backup

\`cmd/update_apply_test.go\` (5 new):
- \`applyTemplatesUpdateAtomic\` first install
- \`applyTemplatesUpdateAtomic\` empty bundle leaves dest untouched
- \`applyTemplatesUpdateAtomic\` \`--backup\` keeps \`.bak\`
- \`applyModuleUpdateAtomic\` empty moduleID guard
- \`applyModuleUpdateAtomic\` lands at \`<modulesDir>/<id>/\`

## v0.10.0 #174 acceptance criteria

- [x] Tier 1: stubs return non-nil errors (PR #187)
- [x] Tier 2: ZIP extract + atomic replace + backup + validation
- [x] kill -9 mid-apply leaves EITHER old OR new — never half
- [x] Backup created before apply (timestamped sibling)
- [ ] \`--verify-signature\` integration — deferred (signature verification itself is still stubbed; flag remains a no-op until that lands, which is a separate v0.11.0 piece)
- [ ] \`RUN_INTEGRATION=1\` smoke covering full download → extract → apply — deferred (atomic-replace covered at unit level; live network download-and-apply needs separate gating)
- [x] CHANGELOG callout — covered by \`--experimental\` gating + commit message