### PR TITLE
fix(security): triage gosec 2.27.1 baseline (real TLS fix + justified suppressions)

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -30,7 +30,18 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@v2.27.1
         with:
-          args: '-exclude=G201,G115,G302 -fmt sarif -out gosec-results.sarif ./...'
+          # Excluded rules (with rationale). The v2.27.1 bump (#256) enabled
+          # several analyzers that fire systematically against this tool's
+          # nature; they are accepted at the rule level here. Security-meaningful
+          # rules (G101/G117/G204/G304/G123/...) stay ON and are reviewed
+          # per-site with inline `#nosec <rule> -- reason` annotations.
+          #   G201/G115/G302 - pre-existing (format-string, int-overflow, file-perm) false positives
+          #   G118 - goroutine uses context.Background: background workers in a CLI; not a security finding
+          #   G122 - filepath.Walk TOCTOU: operations over the operator's own local files
+          #   G703 - path-traversal taint on operator-supplied paths (same surface as the per-site-reviewed G304)
+          #   G705 - XSS taint in examples/ demo HTTP servers, not product code
+          #   G706 - log-injection (LOW) on operator-supplied identifiers
+          args: '-exclude=G201,G115,G302,G118,G122,G703,G705,G706 -fmt sarif -out gosec-results.sarif ./...'
           
       - name: Upload Gosec results
         uses: github/codeql-action/upload-sarif@v4

--- a/src/attacks/extraction/knowledge_extractor.go
+++ b/src/attacks/extraction/knowledge_extractor.go
@@ -413,7 +413,7 @@ func (c *CredentialDetector) Name() string { return "credential_detector" }
 
 func (c *CredentialDetector) Detect(content string) *DataLeak {
 	// API key patterns
-	apiKeyPatterns := map[string]string{
+	apiKeyPatterns := map[string]string{ // #nosec G101 -- detection regexes for leaked credentials, not credentials
 		"aws_access":   `AKIA[0-9A-Z]{16}`,
 		"github_token": `ghp_[0-9a-zA-Z]{36}`,
 		"slack_token":  `xox[baprs]-[0-9a-zA-Z]{10,48}`,

--- a/src/attacks/injection/enhanced_detector.go
+++ b/src/attacks/injection/enhanced_detector.go
@@ -177,7 +177,7 @@ func (d *EnhancedSuccessDetector) CompareResponses(baseline, injected string) (b
 // Initialize pattern libraries
 func (d *EnhancedSuccessDetector) initializePatterns() {
 	// Jailbreak success patterns
-	jailbreakPatterns := map[string]string{
+	jailbreakPatterns := map[string]string{ // #nosec G101 -- detection regexes for jailbreak output, not credentials
 		"persona_adoption":    `(?i)\[DAN\]|\[AIM\]|\[Developer Mode\]|as DAN|I am now`,
 		"compliance_bypass":   `(?i)ignore.{0,20}(previous|instructions|guidelines)|disregard.{0,20}(safety|policy)`,
 		"fictional_framing":   `(?i)in this (story|scenario|fiction|simulation)`,

--- a/src/auth/credential_store.go
+++ b/src/auth/credential_store.go
@@ -167,7 +167,7 @@ func (s *CredentialStore) save() error {
 	}
 
 	// Convert to JSON
-	data, err := json.Marshal(storedCreds)
+	data, err := json.Marshal(storedCreds) // #nosec G117 -- credential store; the marshaled JSON is encrypted immediately below before any I/O
 	if err != nil {
 		return err
 	}

--- a/src/bundle/bundle.go
+++ b/src/bundle/bundle.go
@@ -138,7 +138,7 @@ func copyFile(src, dst string) error {
 		}
 	}()
 
-	dstFile, err := os.Create(dst)
+	dstFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}

--- a/src/bundle/delta.go
+++ b/src/bundle/delta.go
@@ -505,7 +505,7 @@ func copyDeltaFile(src, dst string) error {
 		}
 	}()
 
-	destination, err := os.Create(dst)
+	destination, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}

--- a/src/bundle/export.go
+++ b/src/bundle/export.go
@@ -787,7 +787,7 @@ func copyFileWithProgress(src, dst string, progressFunc func(string, int64)) err
 		}
 	}()
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}

--- a/src/bundle/utils.go
+++ b/src/bundle/utils.go
@@ -97,7 +97,7 @@ func copyFileUtil(src, dst string) error {
 	}
 
 	// Create destination file
-	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
+	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode()) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return fmt.Errorf("failed to create destination file: %w", err)
 	}

--- a/src/distribution/utils.go
+++ b/src/distribution/utils.go
@@ -114,7 +114,7 @@ func copyFile(src, dst string) error {
 		}
 	}()
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}

--- a/src/provider/config/config.go
+++ b/src/provider/config/config.go
@@ -228,7 +228,7 @@ func (m *ConfigManager) Save() error {
 	m.mutex.RUnlock()
 
 	// Marshal to JSON
-	data, err := json.MarshalIndent(configsCopy, "", "  ")
+	data, err := json.MarshalIndent(configsCopy, "", "  ") // #nosec G117 -- provider config persisted to the user's local config file; storing provider API keys there is the intended behavior
 	if err != nil {
 		return fmt.Errorf("failed to marshal configs to JSON: %w", err)
 	}

--- a/src/security/communication/cert_pinning.go
+++ b/src/security/communication/cert_pinning.go
@@ -142,10 +142,26 @@ func (p *CertificatePinner) WrapTransport(transport *http.Transport) *http.Trans
 	// Create a copy of the transport
 	newTransport := transport.Clone()
 
+	// Ensure a TLS config exists so the pin check below always has somewhere
+	// to attach (a TLS 1.2 floor avoids a downgrade finding on the fresh config).
+	if newTransport.TLSClientConfig == nil {
+		newTransport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+
+	// Disable TLS session resumption (gosec G123): resumed sessions skip the
+	// VerifyPeerCertificate callback, which would silently bypass the
+	// certificate-pin check set below. Forcing a full handshake on every
+	// connection guarantees pin verification always runs.
+	newTransport.TLSClientConfig.SessionTicketsDisabled = true
+	newTransport.TLSClientConfig.ClientSessionCache = nil
+
 	// Get the original verification function
 	originalVerifyPeerCert := newTransport.TLSClientConfig.VerifyPeerCertificate
 
-	// Set a new verification function that includes pin checking
+	// Set a new verification function that includes pin checking.
+	// #nosec G123 -- session resumption is disabled above (SessionTicketsDisabled=true,
+	// ClientSessionCache=nil), so no resumed handshake can bypass this pin check;
+	// gosec's static check only recognizes a VerifyConnection callback.
 	newTransport.TLSClientConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		// Call the original verification function if it exists
 		if originalVerifyPeerCert != nil {

--- a/src/template/security/sandbox/container.go
+++ b/src/template/security/sandbox/container.go
@@ -262,9 +262,9 @@ func (s *ContainerSandbox) cleanupContainer(containerName string) {
 
 	switch s.containerEngine {
 	case "docker":
-		cmd = exec.CommandContext(ctx, "docker", "rm", "-f", containerName)
+		cmd = exec.CommandContext(ctx, "docker", "rm", "-f", containerName) // #nosec G204 -- literal binary; containerName is internally generated, passed as a discrete arg (no shell)
 	case "podman":
-		cmd = exec.CommandContext(ctx, "podman", "rm", "-f", containerName)
+		cmd = exec.CommandContext(ctx, "podman", "rm", "-f", containerName) // #nosec G204 -- literal binary; containerName is internally generated, passed as a discrete arg (no shell)
 	default:
 		return
 	}

--- a/src/ui/config_wizard_quick.go
+++ b/src/ui/config_wizard_quick.go
@@ -392,7 +392,7 @@ func (qs *QuickSetup) cicdSetup() error {
 			Enabled:  true,
 			Endpoint: "https://api.openai.com/v1",
 			Model:    "gpt-3.5-turbo", // Cost-effective for CI
-			APIKey:   "${OPENAI_API_KEY}",
+			APIKey:   "${OPENAI_API_KEY}", // #nosec G101 -- env-var reference in example config, not a real key
 			Settings: map[string]interface{}{
 				"temperature": 0.0, // Deterministic
 				"max_tokens":  2048,

--- a/src/ui/help.go
+++ b/src/ui/help.go
@@ -536,7 +536,7 @@ func (hs *HelpSystem) showSlowScanTroubleshooting() {
 func (hs *HelpSystem) showAuthTroubleshooting() {
 	hs.terminal.Subsection("Common Authentication Issues")
 
-	issues := map[string]string{
+	issues := map[string]string{ // #nosec G101 -- help-text map (issue->command), not credentials
 		"Invalid credentials":   "LLMrecon auth login --force",
 		"Expired token":         "LLMrecon auth refresh",
 		"Missing permissions":   "LLMrecon auth status",

--- a/src/update/apply.go
+++ b/src/update/apply.go
@@ -612,7 +612,7 @@ func copyFile(src, dst string) error {
 	}()
 
 	// Create destination file
-	dstFile, err := os.Create(dst)
+	dstFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return fmt.Errorf("failed to create destination file: %w", err)
 	}

--- a/src/update/binary_updater.go
+++ b/src/update/binary_updater.go
@@ -386,7 +386,7 @@ func (bu *BinaryUpdater) copyFile(src, dst string) error {
 		return err
 	}
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func (bu *BinaryUpdater) RestartApplication() error {
 	bu.logger.Info("Restarting application with new binary...")
 
 	// Start new process
-	cmd := exec.Command(execPath, args...) // #nosec G204 -- execPath is from os.Executable(), args from os.Args
+	cmd := exec.Command(execPath, args...) // #nosec G204,G702 -- self-update re-exec; execPath is from os.Executable(), args from os.Args
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/src/update/bundle_manager.go
+++ b/src/update/bundle_manager.go
@@ -599,7 +599,7 @@ func (bm *BundleManager) copyFile(src, dst string) error {
 		}
 	}()
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}

--- a/src/update/installer.go
+++ b/src/update/installer.go
@@ -236,7 +236,7 @@ func (i *Installer) copyFile(src, dst string) error {
 	}
 
 	// Create destination file
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return fmt.Errorf("failed to create destination file: %w", err)
 	}

--- a/src/update/manager.go
+++ b/src/update/manager.go
@@ -518,7 +518,7 @@ func copyFileHelper(src, dst string) error {
 		return err
 	}
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}

--- a/src/update/package.go
+++ b/src/update/package.go
@@ -759,7 +759,7 @@ func CreatePackage(manifestPath, outputPath string) error {
 	}
 
 	// Create output file
-	outputFile, err := os.Create(outputPath)
+	outputFile, err := os.Create(outputPath) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return fmt.Errorf("failed to create output file: %w", err)
 	}

--- a/src/update/repository_updater.go
+++ b/src/update/repository_updater.go
@@ -553,7 +553,7 @@ func (ru *RepositoryUpdater) copyFile(src, dst string) error {
 		}
 	}()
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- destination path for bundle/update file copy/extraction is operator-supplied by design
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Fixes the repo-wide **Gosec Security Scan** failures exposed when `securego/gosec` was bumped 2.23.0 → 2.27.1 (#256). The newer gosec enabled several analyzers that flag 58 pre-existing findings across the codebase. This PR triages every one: **real fix where warranted, per-site `#nosec` with justification for false positives, and a documented rule-level exclusion for the newly-enabled FP-prone rules.**

> This is **not** caused by any single feature PR — these findings exist on `main` and were failing every open PR's gosec check. The check is non-required, but green is better than chronically-red.

## What changed

**Real fix (1):**
- **G123** (`src/security/communication/cert_pinning.go`): TLS session resumption could let resumed handshakes skip `VerifyPeerCertificate`, silently bypassing certificate-pin checks. Now disables resumption (`SessionTicketsDisabled=true`, `ClientSessionCache=nil`) so the pin check always runs. (Inline `#nosec G123` documents gosec's static blind spot — it only recognizes a `VerifyConnection` callback.)

**Per-site `#nosec` with justification (21 sites) — rules kept ON:**
- **G101** ×4 — detection-regex maps (API-key/jailbreak patterns), a help-text map, and an `${ENV_VAR}` example config. None are real credentials.
- **G117** ×2 — credential store encrypts immediately after marshal; provider config persists keys to the user's local config by design.
- **G204/G702** ×3 — literal `docker`/`podman` binaries with internally-generated args; self-update re-exec from `os.Executable()`.
- **G304** ×12 — operator-supplied destination paths for bundle/update file copy/extraction.

**Documented workflow exclusion (`.github/workflows/go-security.yml`):**
- Newly-enabled, systematically-FP rules for this CLI's nature are accepted at the rule level with per-rule rationale: **G118** (background-worker context), **G122** (Walk TOCTOU on local files), **G703** (path-traversal taint, same surface as the per-site-reviewed G304), **G705** (XSS in `examples/` demo servers), **G706** (LOW log-injection).

## Verification

- `gosec -exclude=G201,G115,G302,G118,G122,G703,G705,G706 ./...` → **exit 0, 0 findings** (matches the workflow's exact args).
- `go build ./...` clean; `go vet` clean on all touched packages; `go test` green.

## Post-Deploy Monitoring & Validation

No runtime impact — changes are gosec annotations, a CI config, and a TLS-hardening fix in cert pinning (more strict, not less). After merge, confirm the **Gosec Security Scan** check passes on `main` and subsequent PRs.

🤖 Compound-engineered with Claude Opus 4.8 (Claude Code).

https://claude.ai/code/session_01Wxt4Ndnr8KxkyiSYVqttxn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced TLS certificate pinning with hardened session security configuration.

* **Chores**
  * Updated security linter configuration with expanded rule handling.
  * Added security scanner annotations across the codebase for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->