### PR TITLE
fix(update): real checksum verification in VerifyPackage (#224) — v0.11.0 Phase 1

### DIFF
--- a/src/update/verification.go
+++ b/src/update/verification.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/perplext/LLMrecon/src/version"
 )
@@ -50,16 +51,8 @@ func (v *IntegrityVerifier) VerifyPackage(pkg *UpdatePackage) (*VerificationResu
 		}, fmt.Errorf("manifest file not found")
 	}
 
-	// TODO: Implement manifest checksum verification
-	// The PackageManifest structure doesn't have a Checksums field currently
-
-	// TODO: Implement checksum verification using component checksums
-	// Current PackageManifest structure uses Components field with individual checksums
-	// rather than a centralized Checksums field
-
-	// For now, we'll skip checksum verification
-
-	// Verify digital signature if provided.
+	// Verify digital signature if provided — a hard refusal that precedes
+	// checksum work.
 	//
 	// v0.10.0 #174 Tier 1: refuse rather than silently log+pass when a
 	// signature is present but the verifier is unimplemented. Operators
@@ -74,13 +67,107 @@ func (v *IntegrityVerifier) VerifyPackage(pkg *UpdatePackage) (*VerificationResu
 		}, fmt.Errorf("digital signature verification not implemented; cannot verify signed bundle")
 	}
 
+	// Verify the component checksums declared in the manifest against the
+	// package payloads on disk. Honesty invariant (#224): an IntegrityVerifier
+	// must not return Success:true unless it actually verified integrity. This
+	// replaces the prior "skip checksum verification" path that returned
+	// success unconditionally.
+	verified, err := v.verifyComponentChecksums(pkg)
+	if err != nil {
+		fmt.Fprintf(v.Logger, "Component checksum verification failed: %v\n", err)
+		return &VerificationResult{
+			Success: false,
+			Message: fmt.Sprintf("Component checksum verification failed: %v", err),
+			Details: map[string]interface{}{"verified_components": verified},
+		}, fmt.Errorf("component checksum verification failed: %w", err)
+	}
+	if verified == 0 {
+		// Nothing was verifiable — the manifest declares no component checksums.
+		// Refuse to claim integrity success rather than silently passing.
+		return &VerificationResult{
+			Success: false,
+			Message: "Manifest declares no component checksums; package integrity cannot be verified",
+		}, fmt.Errorf("no component checksums declared; cannot verify package integrity")
+	}
+
 	// Log verification success
-	fmt.Fprintf(v.Logger, "Package integrity verification successful\n")
+	fmt.Fprintf(v.Logger, "Package integrity verification successful (%d component checksum(s) verified)\n", verified)
 
 	return &VerificationResult{
 		Success: true,
 		Message: "Package integrity verification successful",
+		Details: map[string]interface{}{"verified_components": verified},
 	}, nil
+}
+
+// verifyComponentChecksums verifies every component checksum declared in the
+// package manifest against the corresponding payload on disk, and returns the
+// number of checksums successfully verified.
+//
+// Payload layout convention (relative to pkg.PackagePath, an extracted package
+// directory):
+//   - templates:  templates/            (directory hash)
+//   - modules:    modules/<module-id>   (file hash)
+//   - binary:     binary/<platform>     (file hash, per declared platform)
+//
+// A declared checksum whose payload is missing, unreadable, or mismatched is a
+// hard failure (returns an error) — the verifier never treats an unverifiable
+// declared checksum as a pass.
+func (v *IntegrityVerifier) verifyComponentChecksums(pkg *UpdatePackage) (int, error) {
+	verified := 0
+	c := pkg.Manifest.Components
+
+	// Templates component — directory hash.
+	if c.Templates.Checksum != "" {
+		dir := filepath.Join(pkg.PackagePath, "templates")
+		got, err := calculateDirectoryHash(dir)
+		if err != nil {
+			return verified, fmt.Errorf("templates payload: %w", err)
+		}
+		if !hashEqual(got, c.Templates.Checksum) {
+			return verified, fmt.Errorf("templates checksum mismatch (manifest %s, computed %s)", c.Templates.Checksum, got)
+		}
+		verified++
+	}
+
+	// Module components — per-module file hash.
+	for _, m := range c.Modules {
+		if m.Checksum == "" {
+			continue
+		}
+		path := filepath.Join(pkg.PackagePath, "modules", m.ID)
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return verified, fmt.Errorf("module %q payload: %w", m.ID, err)
+		}
+		if !hashEqual(calculateFileHash(data), m.Checksum) {
+			return verified, fmt.Errorf("module %q checksum mismatch", m.ID)
+		}
+		verified++
+	}
+
+	// Binary component — per-platform file hash.
+	for platform, sum := range c.Binary.Checksums {
+		if sum == "" {
+			continue
+		}
+		path := filepath.Join(pkg.PackagePath, "binary", platform)
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return verified, fmt.Errorf("binary[%s] payload: %w", platform, err)
+		}
+		if !hashEqual(calculateFileHash(data), sum) {
+			return verified, fmt.Errorf("binary[%s] checksum mismatch", platform)
+		}
+		verified++
+	}
+
+	return verified, nil
+}
+
+// hashEqual compares two hex-encoded SHA-256 digests case-insensitively.
+func hashEqual(a, b string) bool {
+	return strings.EqualFold(a, b)
 }
 
 // VerifyCompatibility verifies that the update package is compatible with the current installation

--- a/src/update/verification.go
+++ b/src/update/verification.go
@@ -130,12 +130,18 @@ func (v *IntegrityVerifier) verifyComponentChecksums(pkg *UpdatePackage) (int, e
 		verified++
 	}
 
-	// Module components — per-module file hash.
+	// Module components — per-module file hash. Module IDs come from the
+	// (untrusted) manifest, so the resolved path must be confined to the
+	// package directory: a manifest with ID "../../etc/passwd" must not let the
+	// verifier read outside the package (existence/hash-oracle traversal).
 	for _, m := range c.Modules {
 		if m.Checksum == "" {
 			continue
 		}
 		path := filepath.Join(pkg.PackagePath, "modules", m.ID)
+		if !isPathWithinBase(pkg.PackagePath, path) {
+			return verified, fmt.Errorf("module %q: payload path escapes the package directory", m.ID)
+		}
 		data, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return verified, fmt.Errorf("module %q payload: %w", m.ID, err)
@@ -146,12 +152,16 @@ func (v *IntegrityVerifier) verifyComponentChecksums(pkg *UpdatePackage) (int, e
 		verified++
 	}
 
-	// Binary component — per-platform file hash.
+	// Binary component — per-platform file hash. Platform names are also
+	// manifest-controlled and confined the same way.
 	for platform, sum := range c.Binary.Checksums {
 		if sum == "" {
 			continue
 		}
 		path := filepath.Join(pkg.PackagePath, "binary", platform)
+		if !isPathWithinBase(pkg.PackagePath, path) {
+			return verified, fmt.Errorf("binary[%s]: payload path escapes the package directory", platform)
+		}
 		data, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return verified, fmt.Errorf("binary[%s] payload: %w", platform, err)
@@ -163,6 +173,17 @@ func (v *IntegrityVerifier) verifyComponentChecksums(pkg *UpdatePackage) (int, e
 	}
 
 	return verified, nil
+}
+
+// isPathWithinBase reports whether target resolves to a location inside base.
+// Guards manifest-supplied path segments (module IDs, platform names) against
+// directory traversal.
+func isPathWithinBase(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel)
 }
 
 // hashEqual compares two hex-encoded SHA-256 digests case-insensitively.

--- a/src/update/verification_test.go
+++ b/src/update/verification_test.go
@@ -1,0 +1,145 @@
+package update
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeManifestStub creates the manifest.yaml file VerifyPackage stats for
+// existence. Its contents are irrelevant — VerifyPackage reads pkg.Manifest
+// (the in-memory struct), not this file.
+func writeManifestStub(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("schema_version: 1\n"), 0o600); err != nil {
+		t.Fatalf("write manifest stub: %v", err)
+	}
+}
+
+func newVerifier() *IntegrityVerifier { return NewIntegrityVerifier(io.Discard) }
+
+// TestVerifyPackage_NoChecksumsRefuses is the core honesty check (#224): a
+// manifest that declares no component checksums must NOT report success.
+func TestVerifyPackage_NoChecksumsRefuses(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err == nil {
+		t.Fatalf("expected error when no checksums are declared")
+	}
+	if res.Success {
+		t.Errorf("VerifyPackage must not report Success=true without verifying any checksum")
+	}
+}
+
+func TestVerifyPackage_TemplatesChecksumMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+
+	// Lay out a templates/ payload and compute its expected directory hash.
+	tmplDir := filepath.Join(dir, "templates")
+	if err := os.MkdirAll(tmplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "a.yaml"), []byte("payload-a"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want, err := calculateDirectoryHash(tmplDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{
+		Components: Components{Templates: TemplatesComponentInfo{Checksum: want}},
+	}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Success {
+		t.Errorf("expected success on matching templates checksum; msg=%q", res.Message)
+	}
+	if res.Details["verified_components"] != 1 {
+		t.Errorf("verified_components = %v, want 1", res.Details["verified_components"])
+	}
+}
+
+func TestVerifyPackage_TemplatesChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+	tmplDir := filepath.Join(dir, "templates")
+	if err := os.MkdirAll(tmplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "a.yaml"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{
+		Components: Components{Templates: TemplatesComponentInfo{Checksum: "deadbeef"}},
+	}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err == nil || res.Success {
+		t.Errorf("expected failure on checksum mismatch; got success=%v err=%v", res.Success, err)
+	}
+}
+
+func TestVerifyPackage_ModuleChecksumMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+	modDir := filepath.Join(dir, "modules")
+	if err := os.MkdirAll(modDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("module-payload")
+	if err := os.WriteFile(filepath.Join(modDir, "mod1"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{
+		Components: Components{Modules: []ModuleComponentInfo{{ID: "mod1", Checksum: calculateFileHash(content)}}},
+	}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err != nil || !res.Success {
+		t.Errorf("expected success on matching module checksum; success=%v err=%v", res.Success, err)
+	}
+}
+
+func TestVerifyPackage_DeclaredPayloadMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+	// Declares a module checksum but the modules/ payload is absent.
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{
+		Components: Components{Modules: []ModuleComponentInfo{{ID: "ghost", Checksum: "abc123"}}},
+	}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err == nil || res.Success {
+		t.Errorf("expected failure when a declared payload is missing; success=%v err=%v", res.Success, err)
+	}
+}
+
+func TestVerifyPackage_SignatureRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{Signature: "sig-data"}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err == nil || res.Success {
+		t.Errorf("expected refusal on a signed bundle (signature verification unimplemented); success=%v err=%v", res.Success, err)
+	}
+}
+
+func TestVerifyPackage_MissingManifest(t *testing.T) {
+	dir := t.TempDir() // no manifest.yaml written
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err == nil || res.Success {
+		t.Errorf("expected failure when manifest is absent; success=%v err=%v", res.Success, err)
+	}
+}

--- a/src/update/verification_test.go
+++ b/src/update/verification_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -120,6 +121,53 @@ func TestVerifyPackage_DeclaredPayloadMissing(t *testing.T) {
 	res, err := newVerifier().VerifyPackage(pkg)
 	if err == nil || res.Success {
 		t.Errorf("expected failure when a declared payload is missing; success=%v err=%v", res.Success, err)
+	}
+}
+
+func TestVerifyPackage_BinaryChecksumMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestStub(t, dir)
+	binDir := filepath.Join(dir, "binary")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("binary-payload")
+	if err := os.WriteFile(filepath.Join(binDir, "linux-amd64"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pkg := &UpdatePackage{PackagePath: dir, Manifest: PackageManifest{
+		Components: Components{Binary: BinaryComponentInfo{
+			Checksums: map[string]string{"linux-amd64": calculateFileHash(content)},
+		}},
+	}}
+
+	res, err := newVerifier().VerifyPackage(pkg)
+	if err != nil || !res.Success {
+		t.Errorf("expected success on matching binary checksum; success=%v err=%v", res.Success, err)
+	}
+}
+
+// A manifest whose module ID or platform name escapes the package directory
+// must be rejected before any file read (path-traversal / hash-oracle guard).
+func TestVerifyPackage_PathTraversalRejected(t *testing.T) {
+	cases := map[string]PackageManifest{
+		"module id traversal": {Components: Components{Modules: []ModuleComponentInfo{{ID: "../../../etc/passwd", Checksum: "abc"}}}},
+		"platform traversal":  {Components: Components{Binary: BinaryComponentInfo{Checksums: map[string]string{"../../../etc/hosts": "abc"}}}},
+	}
+	for name, manifest := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeManifestStub(t, dir)
+			pkg := &UpdatePackage{PackagePath: dir, Manifest: manifest}
+
+			res, err := newVerifier().VerifyPackage(pkg)
+			if err == nil || res.Success {
+				t.Errorf("expected rejection of traversal path; success=%v err=%v", res.Success, err)
+			}
+			if !strings.Contains(err.Error(), "escapes the package directory") {
+				t.Errorf("error %q should report the path escape", err.Error())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

**v0.11.0 stabilization — Phase 1 (honesty cleanup), part 1.** Fixes the P1 honesty/security bug #224: `IntegrityVerifier.VerifyPackage` returned `Success: true` with the message *"Package integrity verification successful"* while performing **zero** checksum verification (`// For now, we'll skip checksum verification`).

## The fix

`VerifyPackage` now performs **real** component-checksum verification:
- Hashes each component payload declared in the manifest and compares to the declared checksum:
  - `templates/` → directory hash
  - `modules/<id>` → file hash
  - `binary/<platform>` → file hash (per declared platform)
- **Fails** on any mismatch or missing payload.
- When the manifest declares **no** checksums, it **refuses** rather than claiming success — mirroring the existing v0.10.0 #174 signature-refusal fail-safe in the same function. Signed bundles are still refused first (signature verification remains unimplemented).
- Revives the previously-**dead** `calculateFileHash` / `calculateDirectoryHash` helpers (they were written for this and never wired).

### Scope note (surfaced during the fix)
The wider `UpdatePackage` create/verify feature is a **stub**: `CreatePackage` has `// TODO: Add files to package based on manifest` and writes only the manifest (no payloads), and the `package` CLI command is unwired (`rootCmd.AddCommand` commented out). Building the create side is a separate, out-of-stabilization-scope feature. This PR makes the **verifier honest regardless** — it can never again claim integrity success without actually verifying integrity.

## Tests

New `src/update/verification_test.go` (7 cases): templates match / mismatch, module match, declared-payload-missing, no-checksums-refusal, signature-refusal, missing-manifest. Full Go suite green; `go vet` and gosec clean.

## Post-Deploy Monitoring & Validation

No runtime regression to a working flow (the path was unwired + the create side is a stub). The change is strictly *more* strict: it refuses to falsely report integrity success. No additional operational monitoring required.

🤖 Compound-engineered with Claude Opus 4.8 (Claude Code).

https://claude.ai/code/session_01Wxt4Ndnr8KxkyiSYVqttxn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package integrity verification now properly validates all component checksums (templates, modules, binaries) instead of bypassing verification.

* **Tests**
  * Added comprehensive test suite covering package verification scenarios, including checksum matching, mismatches, missing payloads, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->