### PR TITLE
ci(honesty): diff-scoped TODO+return-nil lint (#233) — v0.11.0 Phase 1 final

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -68,3 +68,21 @@ jobs:
       - name: Run govulncheck
         run: |
           govulncheck ./... || echo "Some vulnerabilities found, see output above"
+
+  honesty-lint:
+    name: Honesty Lint
+    runs-on: ubuntu-latest
+    # Diff-scoped: only meaningful against a PR base. Catches a newly-added
+    # `return nil` next to a TODO/FIXME (a stub that claims success) — #233.
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history so merge-base with the PR base resolves
+
+      - name: Run honesty lint
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: python3 scripts/honesty_lint.py --base "origin/${BASE_REF}"

--- a/scripts/honesty_lint.py
+++ b/scripts/honesty_lint.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Honesty lint — catch the next "TODO + return nil" regression (#233).
+
+The v0.10.0/v0.11.0 honesty doctrine forbids a code path that claims success
+(`return nil`) while leaving the work unfinished (`// TODO`). This lint flags a
+`return nil` added within a few lines after a `TODO`/`FIXME` comment.
+
+It is **diff-scoped**: it only inspects lines *added* in the current change, so
+it catches new regressions without requiring the existing tree to be cleaned
+first. A reviewed, intentional case can be suppressed with a trailing
+`// honesty:allow <reason>` on the `return nil` line.
+
+Usage:
+    python3 scripts/honesty_lint.py [--base <ref>]
+    python3 scripts/honesty_lint.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+LOOKBACK = 5  # how many lines above the `return nil` to scan for a TODO
+RETURN_NIL = re.compile(r"^return nil(, nil)?$")
+TODO = re.compile(r"//.*\b(TODO|FIXME)\b", re.IGNORECASE)
+ALLOW = "honesty:allow"
+
+EXCLUDE_PREFIXES = ("attic/",)
+EXCLUDE_SUFFIXES = ("_test.go",)
+
+
+def is_scanned(path: str) -> bool:
+    if not path.endswith(".go"):
+        return False
+    if any(path.startswith(p) for p in EXCLUDE_PREFIXES):
+        return False
+    if any(path.endswith(s) for s in EXCLUDE_SUFFIXES):
+        return False
+    return True
+
+
+def parse_added_lines(diff_text: str) -> dict[str, set[int]]:
+    """Parse `git diff` output into {path: {new_line_numbers_added}}."""
+    added: dict[str, set[int]] = {}
+    path: str | None = None
+    new_lineno = 0
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            continue
+        if line.startswith("@@"):
+            # @@ -a,b +c,d @@  -> next added line is numbered c
+            m = re.search(r"\+(\d+)", line.split("@@")[1])
+            new_lineno = int(m.group(1)) if m else 0
+            continue
+        if path is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added.setdefault(path, set()).add(new_lineno)
+            new_lineno += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            pass  # removed line — does not advance the new-file counter
+        else:
+            new_lineno += 1  # context line
+    return added
+
+
+def find_violations(
+    files: dict[str, list[str]], added: dict[str, set[int]]
+) -> list[tuple[str, int, str]]:
+    """Return [(path, lineno, reason)] for added `return nil` near a TODO."""
+    violations: list[tuple[str, int, str]] = []
+    for path, lines in files.items():
+        if not is_scanned(path):
+            continue
+        added_here = added.get(path, set())
+        for i, raw in enumerate(lines):
+            lineno = i + 1
+            if lineno not in added_here:
+                continue
+            stripped = raw.strip()
+            if not RETURN_NIL.match(stripped):
+                continue
+            if ALLOW in raw:
+                continue
+            # Look back for a TODO/FIXME within LOOKBACK lines.
+            start = max(0, i - LOOKBACK)
+            window = lines[start:i]
+            if any(TODO.search(w) for w in window):
+                todo_rel = next(
+                    (start + j + 1 for j, w in enumerate(window) if TODO.search(w)), lineno
+                )
+                violations.append(
+                    (path, lineno, f"`return nil` claims success but a TODO/FIXME sits at line {todo_rel}")
+                )
+    return violations
+
+
+def _git(args: list[str]) -> str:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True
+    ).stdout
+
+
+def run(base: str) -> int:
+    merge_base = _git(["merge-base", base, "HEAD"]).strip() or base
+    diff = _git(["diff", f"{merge_base}...HEAD"])
+    added = parse_added_lines(diff)
+    files: dict[str, list[str]] = {}
+    for path in added:
+        if is_scanned(path) and os.path.exists(path):
+            with open(path, encoding="utf-8") as fh:
+                files[path] = fh.read().splitlines()
+    violations = find_violations(files, added)
+    if not violations:
+        print("honesty-lint: clean — no new TODO+return-nil regressions.")
+        return 0
+    print("honesty-lint: found honesty regressions in this change:\n")
+    for path, lineno, reason in violations:
+        print(f"  {path}:{lineno}: {reason}")
+    print(
+        "\nEither finish the work, return a typed error, or — if this is a "
+        "reviewed exception — add `// honesty:allow <reason>` to the return line."
+    )
+    return 1
+
+
+def _self_test() -> int:
+    diff = (
+        "+++ b/src/foo.go\n"
+        "@@ -1,2 +1,6 @@\n"
+        " func A() error {\n"
+        "+\t// TODO: implement A\n"
+        "+\treturn nil\n"
+        "+}\n"
+        "+func B() error { return errors.New(\"x\") }\n"
+    )
+    added = parse_added_lines(diff)
+    assert added["src/foo.go"] == {2, 3, 4, 5}, added
+    files = {
+        "src/foo.go": [
+            "func A() error {",
+            "\t// TODO: implement A",
+            "\treturn nil",
+            "}",
+            'func B() error { return errors.New("x") }',
+        ]
+    }
+    v = find_violations(files, added)
+    assert len(v) == 1 and v[0][1] == 3, v
+
+    # Suppression marker silences it.
+    files["src/foo.go"][2] = "\treturn nil // honesty:allow stub kept intentionally"
+    assert find_violations(files, added) == [], "honesty:allow should suppress"
+
+    # Pre-existing (not-added) return nil is ignored.
+    assert find_violations(files, {"src/foo.go": {2}}) == [], "non-added line ignored"
+
+    # Test files and attic are excluded.
+    assert find_violations({"x_test.go": ["//TODO", "return nil"]}, {"x_test.go": {1, 2}}) == []
+    assert find_violations({"attic/x.go": ["//TODO", "return nil"]}, {"attic/x.go": {1, 2}}) == []
+
+    print("honesty_lint self-test: PASS")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default=os.environ.get("HONESTY_BASE", "origin/main"))
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return _self_test()
+    return run(args.base)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_honesty_lint.py
+++ b/tests/test_honesty_lint.py
@@ -1,0 +1,72 @@
+"""Tests for scripts/honesty_lint.py (#233)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import honesty_lint as hl  # noqa: E402
+
+
+def test_parse_added_lines_numbers_added_lines():
+    diff = (
+        "+++ b/src/foo.go\n"
+        "@@ -10,1 +10,3 @@\n"
+        " context line\n"
+        "+added one\n"
+        "+added two\n"
+    )
+    added = hl.parse_added_lines(diff)
+    assert added == {"src/foo.go": {11, 12}}
+
+
+def test_removed_lines_do_not_advance_new_counter():
+    diff = (
+        "+++ b/src/foo.go\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-old line\n"
+        "+new line\n"
+        " unchanged\n"
+    )
+    added = hl.parse_added_lines(diff)
+    assert added == {"src/foo.go": {1}}
+
+
+def test_flags_added_return_nil_after_todo():
+    files = {"src/foo.go": ["func A() error {", "\t// TODO: do it", "\treturn nil", "}"]}
+    added = {"src/foo.go": {2, 3}}
+    v = hl.find_violations(files, added)
+    assert len(v) == 1
+    assert v[0][0] == "src/foo.go" and v[0][1] == 3
+
+
+def test_return_nil_nil_variant_flagged():
+    files = {"src/foo.go": ["// FIXME later", "return nil, nil"]}
+    assert len(hl.find_violations(files, {"src/foo.go": {1, 2}})) == 1
+
+
+def test_honesty_allow_suppresses():
+    files = {"src/foo.go": ["// TODO", "return nil // honesty:allow reviewed"]}
+    assert hl.find_violations(files, {"src/foo.go": {1, 2}}) == []
+
+
+def test_preexisting_line_not_added_is_ignored():
+    files = {"src/foo.go": ["// TODO", "return nil"]}
+    # The return-nil line (2) is NOT in the added set -> not a new regression.
+    assert hl.find_violations(files, {"src/foo.go": {1}}) == []
+
+
+def test_todo_too_far_above_is_ignored():
+    files = {"src/foo.go": ["// TODO"] + ["x"] * hl.LOOKBACK + ["return nil"]}
+    last = len(files["src/foo.go"])
+    assert hl.find_violations(files, {"src/foo.go": {last}}) == []
+
+
+def test_excludes_test_files_and_attic():
+    assert hl.is_scanned("src/foo.go") is True
+    assert hl.is_scanned("src/foo_test.go") is False
+    assert hl.is_scanned("attic/x.go") is False
+    assert hl.is_scanned("README.md") is False
+
+
+def test_bundled_self_test_passes():
+    assert hl._self_test() == 0


### PR DESCRIPTION
## Summary

**v0.11.0 stabilization — Phase 1 (honesty cleanup), final item.** Adds a CI guard (#233) that catches the next "stub that claims success" regression: a `return nil` added next to a `// TODO`/`// FIXME`.

## Design — diff-scoped, not a baseline gate

The lint inspects **only lines added vs the PR base**, so it catches *new* regressions without first requiring a cleanup of the **10 pre-existing** `TODO`→`return nil` hits in the tree (`hsm_manager.go`, `pipeline.go`, `export.go`, `bundle_interactive.go`, `package.go`). That matches the issue's intent — "catch the *next* honesty regression."

- Flags `return nil` (and `return nil, nil`) within 5 lines after a `TODO`/`FIXME`, on an **added** line.
- Reviewed exceptions: trailing `// honesty:allow <reason>` on the return line.
- Excludes `_test.go` and `attic/`.

## Components
- `scripts/honesty_lint.py` — the lint (pure stdlib; `--self-test` mode).
- `tests/test_honesty_lint.py` — 9 pytests: diff parsing, removed-line handling, the `nil, nil` variant, suppression, not-added-line, lookback bound, exclusions.
- `Honesty Lint` job in `.github/workflows/go-security.yml` — runs on PRs to `main` (full history checkout for merge-base), using the safe `env:`-var pattern for the base ref.

## Note
Because GitHub runs the **base branch's** workflow for `pull_request` events, this job won't appear on *this* PR — it protects PRs opened after it merges (same mechanism as the gosec job).

## Post-Deploy Monitoring & Validation
CI-only addition; no runtime impact. After merge, the `Honesty Lint` check appears on new PRs. No additional monitoring required.

🤖 Compound-engineered with Claude Opus 4.8 (Claude Code).

https://claude.ai/code/session_01Wxt4Ndnr8KxkyiSYVqttxn
