### PR TITLE
fix(audit): unique FileLogger rotation filenames to prevent silent merges

### DIFF
--- a/src/audit/trail/log_format_test.go
+++ b/src/audit/trail/log_format_test.go
@@ -1,0 +1,145 @@
+package trail
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewAuditLog_Defaults(t *testing.T) {
+	log := NewAuditLog(OperationCreate, "templates", "created a template")
+
+	if log.ID == "" {
+		t.Error("expected a generated ID")
+	}
+	if log.Level != LogLevelInfo {
+		t.Errorf("default level: got %q want %q", log.Level, LogLevelInfo)
+	}
+	if log.Status != "success" {
+		t.Errorf("default status: got %q want success", log.Status)
+	}
+	if log.Operation != OperationCreate || log.Component != "templates" {
+		t.Errorf("operation/component not set: %+v", log)
+	}
+	if log.Metadata == nil {
+		t.Error("metadata map should be initialized, not nil")
+	}
+	if log.Timestamp.IsZero() {
+		t.Error("timestamp should be set")
+	}
+	if log.Timestamp.Location().String() != "UTC" {
+		t.Errorf("timestamp should be UTC, got %s", log.Timestamp.Location())
+	}
+}
+
+func TestAuditLog_JSONRoundTrip(t *testing.T) {
+	original := NewAuditLog(OperationUpdate, "config", "changed setting").
+		WithUser("u-1", "alice").
+		WithStatus("success", 200).
+		WithTags("security", "config").
+		WithMetadata("region", "us-east")
+
+	jsonStr, err := original.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+
+	parsed, err := FromJSON(jsonStr)
+	if err != nil {
+		t.Fatalf("FromJSON: %v", err)
+	}
+
+	if parsed.ID != original.ID ||
+		parsed.Operation != original.Operation ||
+		parsed.UserID != original.UserID ||
+		parsed.User != original.User ||
+		parsed.StatusCode != original.StatusCode {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", parsed, original)
+	}
+	if len(parsed.Tags) != 2 {
+		t.Errorf("tags lost in round trip: %v", parsed.Tags)
+	}
+}
+
+func TestFromJSON_RejectsMalformed(t *testing.T) {
+	if _, err := FromJSON("{not valid json"); err == nil {
+		t.Fatal("expected an error parsing malformed JSON")
+	}
+}
+
+func TestWithError_SetsErrorStatus(t *testing.T) {
+	log := NewAuditLog(OperationExecute, "runner", "ran").
+		WithError("E_TIMEOUT", "operation timed out")
+
+	if log.Status != "error" {
+		t.Errorf("WithError should flip status to error, got %q", log.Status)
+	}
+	if log.ErrorCode != "E_TIMEOUT" || log.ErrorMessage != "operation timed out" {
+		t.Errorf("error fields not set: %+v", log)
+	}
+}
+
+func TestBuilderChain_AccumulatesFields(t *testing.T) {
+	log := NewAuditLog(OperationAuth, "login", "ok").
+		WithLevel(LogLevelWarning).
+		WithSession("sess-1").
+		WithRequest("req-1", "trace-1").
+		WithClient("10.0.0.1", "curl/8").
+		WithResource("account", "acct-1").
+		WithAction("login").
+		WithDuration(42)
+
+	if log.Level != LogLevelWarning ||
+		log.SessionID != "sess-1" ||
+		log.RequestID != "req-1" ||
+		log.TraceID != "trace-1" ||
+		log.IPAddress != "10.0.0.1" ||
+		log.UserAgent != "curl/8" ||
+		log.Resource != "account" ||
+		log.ResourceID != "acct-1" ||
+		log.Action != "login" ||
+		log.Duration != 42 {
+		t.Errorf("builder chain dropped a field: %+v", log)
+	}
+}
+
+func TestWithMetadata_InitializesNilMap(t *testing.T) {
+	// A zero-value AuditLog has a nil Metadata map; WithMetadata must not panic.
+	log := &AuditLog{}
+	log.WithMetadata("k", "v")
+	if log.Metadata["k"] != "v" {
+		t.Error("WithMetadata should lazily initialize the metadata map")
+	}
+}
+
+func TestWithVersionAndVerification(t *testing.T) {
+	log := NewAuditLog(OperationDeploy, "release", "deployed").
+		WithVersion("1.0.0", "1.1.0", "minor").
+		WithVerification(true, "checksum", map[string]interface{}{"sha": "abc"})
+
+	if log.Version == nil || log.Version.Previous != "1.0.0" || log.Version.Current != "1.1.0" || log.Version.ChangeType != "minor" {
+		t.Errorf("WithVersion not applied: %+v", log.Version)
+	}
+	if log.Verification == nil || !log.Verification.Success || log.Verification.Method != "checksum" {
+		t.Errorf("WithVerification not applied: %+v", log.Verification)
+	}
+	if log.Verification.Details["sha"] != "abc" {
+		t.Errorf("verification details lost: %+v", log.Verification.Details)
+	}
+}
+
+func TestGenerateID_UniqueAndHex(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		id := generateID()
+		if len(id) != 32 { // 16 random bytes hex-encoded
+			t.Fatalf("unexpected ID length %d for %q", len(id), id)
+		}
+		if strings.TrimLeft(id, "0123456789abcdef") != "" {
+			t.Fatalf("ID is not lowercase hex: %q", id)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate ID generated: %q", id)
+		}
+		seen[id] = true
+	}
+}

--- a/src/audit/trail/loggers.go
+++ b/src/audit/trail/loggers.go
@@ -48,6 +48,7 @@ type FileLogger struct {
 	compress     bool
 	mu           sync.Mutex
 	rotationTime time.Time
+	fileSeq      int // monotonic counter ensuring unique filenames across rotations
 }
 
 // NewFileLogger creates a new file-based audit logger
@@ -125,8 +126,13 @@ func (l *FileLogger) Close() error {
 
 // openLogFile opens a new log file
 func (l *FileLogger) openLogFile() error {
+	// Include a monotonic sequence number alongside the timestamp: the
+	// second-granularity timestamp alone collides when rotation fires more
+	// than once within the same second, silently appending rotated entries to
+	// the same file via O_APPEND.
 	timestamp := time.Now().Format("20060102-150405")
-	filename := fmt.Sprintf("audit-%s.log", timestamp)
+	filename := fmt.Sprintf("audit-%s-%06d.log", timestamp, l.fileSeq)
+	l.fileSeq++
 	filePath := filepath.Join(l.directory, filename)
 
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600) // #nosec G304 -- path constructed from struct field directory + timestamp

--- a/src/audit/trail/loggers_test.go
+++ b/src/audit/trail/loggers_test.go
@@ -1,0 +1,168 @@
+package trail
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readAllEntries reads every *.log file in dir and returns the parsed entries.
+// FileLogger names files with second-granularity timestamps, so size-based
+// rotations within the same second land in one file; reading the whole
+// directory makes the test robust to how many files rotation produced.
+func readAllEntries(t *testing.T, dir string) []*AuditLog {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.log"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	var entries []*AuditLog
+	for _, path := range matches {
+		data, err := os.ReadFile(path) // #nosec G304 -- test-controlled temp path
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			entry, err := FromJSON(line)
+			if err != nil {
+				t.Fatalf("parse line %q: %v", line, err)
+			}
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func TestFileLogger_WritesRetrievableEntries(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewFileLogger(dir, 1<<20 /* 1 MiB, no rotation */, 5, false)
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	defer logger.Close()
+
+	for i := 0; i < 3; i++ {
+		if err := logger.Log(context.Background(), NewAuditLog(OperationCreate, "c", "entry")); err != nil {
+			t.Fatalf("Log: %v", err)
+		}
+	}
+
+	entries := readAllEntries(t, dir)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 persisted entries, got %d", len(entries))
+	}
+	for _, e := range entries {
+		if e.Operation != OperationCreate || e.Message != "entry" {
+			t.Errorf("entry did not round-trip from disk: %+v", e)
+		}
+	}
+}
+
+func TestFileLogger_RotationPreservesAllEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Tiny max size forces a rotation check before most writes.
+	logger, err := NewFileLogger(dir, 16 /* bytes */, 10, false)
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	defer logger.Close()
+
+	const n = 8
+	for i := 0; i < n; i++ {
+		if err := logger.Log(context.Background(), NewAuditLog(OperationCreate, "c", "rot")); err != nil {
+			t.Fatalf("Log %d: %v", i, err)
+		}
+	}
+
+	// Whatever the file count, every entry must survive rotation.
+	if got := len(readAllEntries(t, dir)); got != n {
+		t.Fatalf("rotation lost entries: persisted %d, wrote %d", got, n)
+	}
+}
+
+func TestFileLogger_RotationCreatesDistinctFiles(t *testing.T) {
+	dir := t.TempDir()
+	// 16-byte cap forces a rotation before nearly every write. All writes
+	// happen within the same wall-clock second, which is exactly the case the
+	// second-granularity filename scheme used to collide on.
+	logger, err := NewFileLogger(dir, 16, 10, false)
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	defer logger.Close()
+
+	const n = 6
+	for i := 0; i < n; i++ {
+		if err := logger.Log(context.Background(), NewAuditLog(OperationCreate, "c", "rot")); err != nil {
+			t.Fatalf("Log %d: %v", i, err)
+		}
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.log"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	// Each rotation must produce a distinct file; same-second writes must not
+	// silently share one filename.
+	if len(matches) < 2 {
+		t.Fatalf("expected rotation to create distinct files, got %d", len(matches))
+	}
+}
+
+func TestFileLogger_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "audit")
+	logger, err := NewFileLogger(dir, 1<<20, 5, false)
+	if err != nil {
+		t.Fatalf("NewFileLogger should create missing dirs: %v", err)
+	}
+	defer logger.Close()
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected directory to be created: %v", err)
+	}
+}
+
+func TestInMemoryLogger_StoresImmutableCopy(t *testing.T) {
+	logger := NewInMemoryLogger(10)
+	log := NewAuditLog(OperationRead, "c", "original")
+	if err := logger.Log(context.Background(), log); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	// Mutating the caller's struct must not change what the logger retained.
+	log.Message = "mutated after logging"
+
+	if logger.logs[0].Message != "original" {
+		t.Errorf("logger stored a reference, not a copy: %q", logger.logs[0].Message)
+	}
+}
+
+func TestInMemoryLogger_TrimsToMax(t *testing.T) {
+	logger := NewInMemoryLogger(2)
+	for _, msg := range []string{"first", "second", "third"} {
+		if err := logger.Log(context.Background(), NewAuditLog(OperationRead, "c", msg)); err != nil {
+			t.Fatalf("Log: %v", err)
+		}
+	}
+
+	if len(logger.logs) != 2 {
+		t.Fatalf("expected ring trimmed to 2, got %d", len(logger.logs))
+	}
+	// Oldest ("first") should have been dropped; newest two retained in order.
+	if logger.logs[0].Message != "second" || logger.logs[1].Message != "third" {
+		t.Errorf("trim dropped the wrong entries: %q, %q", logger.logs[0].Message, logger.logs[1].Message)
+	}
+}
+
+func TestNewInMemoryLogger_DefaultsNonPositiveMax(t *testing.T) {
+	if got := NewInMemoryLogger(0).maxLogs; got != 1000 {
+		t.Errorf("expected default maxLogs 1000, got %d", got)
+	}
+	if got := NewInMemoryLogger(-5).maxLogs; got != 1000 {
+		t.Errorf("expected default maxLogs 1000 for negative input, got %d", got)
+	}
+}

--- a/src/audit/trail/manager_test.go
+++ b/src/audit/trail/manager_test.go
@@ -1,0 +1,422 @@
+// Package trail provides a comprehensive audit trail and logging system.
+//
+// These are white-box tests (package trail) so they can exercise unexported
+// helpers (logLevelValue) and inspect the manager's internal state directly.
+package trail
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// captureLogger is a minimal AuditLogger test double that records every log it
+// receives. A capturing logger is unavoidable here: InMemoryLogger keeps its
+// backing slice unexported with no getter, so there is no production logger we
+// can read entries back out of. This double tests the *manager's* dispatch
+// behavior, not a mock's behavior.
+type captureLogger struct {
+	id       string
+	received []*AuditLog
+}
+
+func (l *captureLogger) GetID() string { return l.id }
+
+func (l *captureLogger) Log(_ context.Context, log *AuditLog) error {
+	l.received = append(l.received, log)
+	return nil
+}
+
+func (l *captureLogger) Close() error { return nil }
+
+// failingLogger always returns an error from Log. There is no production logger
+// that deterministically fails, so this double is required to test the
+// manager's "continue on logger failure" contract.
+type failingLogger struct {
+	id  string
+	err error
+}
+
+func (l *failingLogger) GetID() string { return l.id }
+
+func (l *failingLogger) Log(_ context.Context, _ *AuditLog) error { return l.err }
+
+func (l *failingLogger) Close() error { return nil }
+
+// queryExportLogger implements the optional AuditQueryLogger and AuditExporter
+// interfaces so the manager's Query/Export delegation can be exercised. No
+// concrete production logger implements these, so a double is required.
+type queryExportLogger struct {
+	id           string
+	queryResult  *LogQueryResult
+	exportResult []byte
+}
+
+func (l *queryExportLogger) GetID() string                            { return l.id }
+func (l *queryExportLogger) Log(_ context.Context, _ *AuditLog) error { return nil }
+func (l *queryExportLogger) Close() error                             { return nil }
+
+func (l *queryExportLogger) Query(_ context.Context, _ *LogQuery) (*LogQueryResult, error) {
+	return l.queryResult, nil
+}
+
+func (l *queryExportLogger) Export(_ context.Context, _ []*AuditLog, _ ExportFormat) ([]byte, error) {
+	return l.exportResult, nil
+}
+
+func tamperEvidentManager(t *testing.T) *AuditTrailManager {
+	t.Helper()
+	m, err := NewAuditTrailManager(&AuditConfig{
+		MinLogLevel:   LogLevelDebug,
+		TamperEvident: true,
+		SigningKey:    "test-signing-key-32-bytes-or-more!!",
+	})
+	if err != nil {
+		t.Fatalf("NewAuditTrailManager: %v", err)
+	}
+	return m
+}
+
+// --- Tamper-evidence: the audit trail's crown jewel -------------------------
+
+func TestVerifyLogIntegrity_AcceptsUntamperedLog(t *testing.T) {
+	m := tamperEvidentManager(t)
+	log := NewAuditLog(OperationAuth, "login", "user authenticated")
+
+	if err := m.Log(context.Background(), log); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	if log.Signature == "" {
+		t.Fatal("expected Log to populate a signature when tamper-evident")
+	}
+
+	ok, err := m.VerifyLogIntegrity(log)
+	if err != nil {
+		t.Fatalf("VerifyLogIntegrity: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected untampered log to verify as intact")
+	}
+}
+
+func TestVerifyLogIntegrity_DetectsTampering(t *testing.T) {
+	m := tamperEvidentManager(t)
+	log := NewAuditLog(OperationDelete, "templates", "deleted template X")
+	if err := m.Log(context.Background(), log); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	// Mutate the signed entry the way an attacker covering their tracks would.
+	log.Message = "deleted template Y"
+
+	ok, err := m.VerifyLogIntegrity(log)
+	if err != nil {
+		t.Fatalf("VerifyLogIntegrity: %v", err)
+	}
+	if ok {
+		t.Fatal("expected a mutated log to fail integrity verification")
+	}
+}
+
+func TestVerifyLogIntegrity_RestoresSignatureAfterCheck(t *testing.T) {
+	// VerifyLogIntegrity temporarily blanks Signature to recompute it; it must
+	// put the original back so the entry stays verifiable on a second call.
+	m := tamperEvidentManager(t)
+	log := NewAuditLog(OperationConfig, "settings", "changed retention")
+	if err := m.Log(context.Background(), log); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	original := log.Signature
+
+	if _, err := m.VerifyLogIntegrity(log); err != nil {
+		t.Fatalf("VerifyLogIntegrity: %v", err)
+	}
+	if log.Signature != original {
+		t.Fatalf("signature not restored: got %q want %q", log.Signature, original)
+	}
+}
+
+func TestVerifyLogIntegrity_ErrorsWhenNotTamperEvident(t *testing.T) {
+	m, err := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	if err != nil {
+		t.Fatalf("NewAuditTrailManager: %v", err)
+	}
+	if _, err := m.VerifyLogIntegrity(NewAuditLog(OperationRead, "c", "m")); err == nil {
+		t.Fatal("expected an error when tamper-evident logging is disabled")
+	}
+}
+
+func TestVerifyLogIntegrity_ErrorsOnMissingSignature(t *testing.T) {
+	m := tamperEvidentManager(t)
+	// A log that was never passed through Log() has no signature.
+	if _, err := m.VerifyLogIntegrity(NewAuditLog(OperationRead, "c", "m")); err == nil {
+		t.Fatal("expected an error for a log with no signature")
+	}
+}
+
+// --- Redaction: secrets must never reach a logger ---------------------------
+
+func TestLog_RedactsConfiguredMetadataFields(t *testing.T) {
+	m, err := NewAuditTrailManager(&AuditConfig{
+		MinLogLevel:         LogLevelDebug,
+		RedactSensitiveInfo: true,
+		RedactFields:        []string{"password", "token"},
+	})
+	if err != nil {
+		t.Fatalf("NewAuditTrailManager: %v", err)
+	}
+
+	log := NewAuditLog(OperationAuth, "login", "attempt").
+		WithMetadata("password", "hunter2").
+		WithMetadata("token", "abc123").
+		WithMetadata("username", "alice")
+	if err := m.Log(context.Background(), log); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	if got := log.Metadata["password"]; got != "[REDACTED]" {
+		t.Errorf("password not redacted: got %v", got)
+	}
+	if got := log.Metadata["token"]; got != "[REDACTED]" {
+		t.Errorf("token not redacted: got %v", got)
+	}
+	if got := log.Metadata["username"]; got != "alice" {
+		t.Errorf("non-sensitive field altered: got %v", got)
+	}
+}
+
+func TestLog_RedactsChangeBeforeAndAfterStates(t *testing.T) {
+	m, err := NewAuditTrailManager(&AuditConfig{
+		MinLogLevel:         LogLevelDebug,
+		RedactSensitiveInfo: true,
+		RedactFields:        []string{"secret"},
+	})
+	if err != nil {
+		t.Fatalf("NewAuditTrailManager: %v", err)
+	}
+
+	log := NewAuditLog(OperationUpdate, "creds", "rotated").
+		WithChanges(
+			map[string]interface{}{"secret": "old"},
+			map[string]interface{}{"secret": "new"},
+			[]string{"secret"}, "rotation")
+	if err := m.Log(context.Background(), log); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	if got := log.Changes.Before["secret"]; got != "[REDACTED]" {
+		t.Errorf("before-state secret not redacted: got %v", got)
+	}
+	if got := log.Changes.After["secret"]; got != "[REDACTED]" {
+		t.Errorf("after-state secret not redacted: got %v", got)
+	}
+}
+
+// --- Level filtering --------------------------------------------------------
+
+func TestLog_DropsEntriesBelowMinLevel(t *testing.T) {
+	m, err := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelWarning})
+	if err != nil {
+		t.Fatalf("NewAuditTrailManager: %v", err)
+	}
+	cap := &captureLogger{id: "cap"}
+	m.AddLogger(cap)
+
+	// Below threshold: must be dropped silently.
+	if err := m.Log(context.Background(), NewAuditLog(OperationRead, "c", "debug").WithLevel(LogLevelInfo)); err != nil {
+		t.Fatalf("Log(info): %v", err)
+	}
+	if len(cap.received) != 0 {
+		t.Fatalf("info entry should have been dropped below warning threshold, got %d", len(cap.received))
+	}
+
+	// At/above threshold: must be delivered.
+	if err := m.Log(context.Background(), NewAuditLog(OperationRead, "c", "warn").WithLevel(LogLevelError)); err != nil {
+		t.Fatalf("Log(error): %v", err)
+	}
+	if len(cap.received) != 1 {
+		t.Fatalf("error entry should have been delivered, got %d", len(cap.received))
+	}
+}
+
+func TestLogLevelValue_Ordering(t *testing.T) {
+	levels := []LogLevel{LogLevelDebug, LogLevelInfo, LogLevelWarning, LogLevelError, LogLevelCritical}
+	for i := 1; i < len(levels); i++ {
+		if logLevelValue(levels[i-1]) >= logLevelValue(levels[i]) {
+			t.Errorf("level %q should rank below %q", levels[i-1], levels[i])
+		}
+	}
+	// Unknown levels default to info's rank.
+	if logLevelValue(LogLevel("bogus")) != logLevelValue(LogLevelInfo) {
+		t.Error("unknown level should default to info rank")
+	}
+}
+
+// --- Dispatch resilience ----------------------------------------------------
+
+func TestLog_ContinuesAfterLoggerFailure(t *testing.T) {
+	m, err := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	if err != nil {
+		t.Fatalf("NewAuditTrailManager: %v", err)
+	}
+	boom := errors.New("disk full")
+	m.AddLogger(&failingLogger{id: "bad", err: boom})
+	good := &captureLogger{id: "good"}
+	m.AddLogger(good)
+
+	err = m.Log(context.Background(), NewAuditLog(OperationCreate, "c", "m"))
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected the failing logger's error to surface, got %v", err)
+	}
+	if len(good.received) != 1 {
+		t.Fatalf("healthy logger should still receive the entry, got %d", len(good.received))
+	}
+}
+
+// --- Logger management & query validation -----------------------------------
+
+func TestRemoveLogger(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	m.AddLogger(&captureLogger{id: "keep"})
+
+	if err := m.RemoveLogger("does-not-exist"); !errors.Is(err, ErrLoggerNotFound) {
+		t.Fatalf("expected ErrLoggerNotFound, got %v", err)
+	}
+	if err := m.RemoveLogger("keep"); err != nil {
+		t.Fatalf("removing existing logger: %v", err)
+	}
+}
+
+func TestQuery_RejectsInvertedTimeRange(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	now := time.Now()
+	_, err := m.Query(context.Background(), &LogQuery{
+		StartTime: now,
+		EndTime:   now.Add(-time.Hour),
+	})
+	if !errors.Is(err, ErrInvalidTimeRange) {
+		t.Fatalf("expected ErrInvalidTimeRange, got %v", err)
+	}
+}
+
+func TestQuery_EmptyWhenNoLoggers(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	res, err := m.Query(context.Background(), &LogQuery{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if res.TotalCount != 0 || len(res.Logs) != 0 || res.HasMore {
+		t.Fatalf("expected empty result, got %+v", res)
+	}
+}
+
+func TestGetConfig_ReturnsDefensiveCopy(t *testing.T) {
+	m := tamperEvidentManager(t)
+	got := m.GetConfig()
+	got.MinLogLevel = LogLevelCritical // mutate the copy
+
+	if m.GetLogLevel() == LogLevelCritical {
+		t.Fatal("GetConfig must return a copy; mutating it changed the manager")
+	}
+}
+
+func TestSetLogLevel(t *testing.T) {
+	m := tamperEvidentManager(t)
+	m.SetLogLevel(LogLevelError)
+	if m.GetLogLevel() != LogLevelError {
+		t.Fatalf("SetLogLevel not reflected: got %q", m.GetLogLevel())
+	}
+}
+
+func TestQuery_DelegatesToQueryableLogger(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	want := &LogQueryResult{
+		Logs:       []*AuditLog{NewAuditLog(OperationRead, "c", "hit")},
+		TotalCount: 1,
+	}
+	// A plain capture logger does not support querying; the queryable one does.
+	m.AddLogger(&captureLogger{id: "plain"})
+	m.AddLogger(&queryExportLogger{id: "queryable", queryResult: want})
+
+	got, err := m.Query(context.Background(), &LogQuery{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if got.TotalCount != 1 || len(got.Logs) != 1 {
+		t.Fatalf("expected delegation to the queryable logger, got %+v", got)
+	}
+}
+
+func TestQuery_ErrorsWhenNoLoggerSupportsQuerying(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	m.AddLogger(&captureLogger{id: "plain"}) // no Query method
+	if _, err := m.Query(context.Background(), &LogQuery{}); err == nil {
+		t.Fatal("expected an error when no logger supports querying")
+	}
+}
+
+func TestExport_DelegatesToExporter(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	m.AddLogger(&queryExportLogger{
+		id:           "exporter",
+		queryResult:  &LogQueryResult{Logs: []*AuditLog{}},
+		exportResult: []byte("exported-bytes"),
+	})
+
+	out, err := m.Export(context.Background(), &LogQuery{}, FormatJSON)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if string(out) != "exported-bytes" {
+		t.Fatalf("expected delegation to exporter, got %q", out)
+	}
+}
+
+func TestDefaultAuditConfig_SecureDefaults(t *testing.T) {
+	cfg := DefaultAuditConfig()
+	// Security posture: tamper-evidence and redaction must be ON by default.
+	if !cfg.TamperEvident {
+		t.Error("tamper-evident logging should default to enabled")
+	}
+	if !cfg.RedactSensitiveInfo {
+		t.Error("sensitive-info redaction should default to enabled")
+	}
+	for _, want := range []string{"password", "token", "key", "secret", "credential"} {
+		found := false
+		for _, f := range cfg.RedactFields {
+			if f == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("default redact fields should include %q", want)
+		}
+	}
+	if cfg.MinLogLevel != LogLevelInfo {
+		t.Errorf("default min level: got %q want info", cfg.MinLogLevel)
+	}
+}
+
+func TestLoggerGetID(t *testing.T) {
+	if got := NewInMemoryLogger(10).GetID(); got != "memory-logger" {
+		t.Errorf("InMemoryLogger ID: got %q", got)
+	}
+}
+
+func TestClose_ClearsLoggers(t *testing.T) {
+	m, _ := NewAuditTrailManager(&AuditConfig{MinLogLevel: LogLevelDebug})
+	cap := &captureLogger{id: "c"}
+	m.AddLogger(cap)
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// After Close, a subsequent log reaches no logger.
+	if err := m.Log(context.Background(), NewAuditLog(OperationRead, "c", "m")); err != nil {
+		t.Fatalf("Log after Close: %v", err)
+	}
+	if len(cap.received) != 0 {
+		t.Fatal("loggers should be cleared after Close")
+	}
+}


### PR DESCRIPTION
## Summary

`FileLogger.openLogFile` named rotated log files with a second-granularity timestamp:

```go
timestamp := time.Now().Format("20060102-150405")
filename := fmt.Sprintf("audit-%s.log", timestamp)
```

If rotation fires more than once within the same second, the filename **collides**. Because the file is opened `O_APPEND`, the "new" rotation silently appends to the existing file instead of starting a fresh one — corrupting the rotation boundary and the size-based rotation accounting (the next rotation check sees an already-large "new" file).

## Fix

Add a monotonic `fileSeq` counter to the `FileLogger` and include it in the filename:

```go
filename := fmt.Sprintf("audit-%s-%06d.log", timestamp, l.fileSeq)
l.fileSeq++
```

Each rotation now gets a distinct file regardless of sub-second timing.

## Tests

Adds `log_format_test.go`, `loggers_test.go`, and `manager_test.go` covering the logger format, rotation behavior, and the trail manager.

## Verification
- `go test ./src/audit/trail/... -race` — green
- `go vet ./src/audit/trail/...` — clean

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9