### PR TITLE
test: cover src/template loader / cache / format pipeline (#229)

### DIFF
--- a/src/template/format/template_test.go
+++ b/src/template/format/template_test.go
@@ -1,0 +1,166 @@
+package format
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func validTemplate() *Template {
+	return &Template{
+		ID:   "tmpl-1",
+		Name: "Test Template",
+		Info: &TemplateInfo{Name: "Test Template", Version: "1.0.0", Severity: "high"},
+		Test: &TemplateTest{},
+	}
+}
+
+func TestValidateStructure(t *testing.T) {
+	if err := validTemplate().Validate(); err != nil {
+		t.Fatalf("valid template should pass: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Template)
+	}{
+		{"missing ID", func(t *Template) { t.ID = "" }},
+		{"missing Name", func(t *Template) { t.Name = "" }},
+		{"missing Info", func(t *Template) { t.Info = nil }},
+		{"missing Test", func(t *Template) { t.Test = nil }},
+	}
+	for _, c := range cases {
+		tmpl := validTemplate()
+		c.mutate(tmpl)
+		if err := tmpl.ValidateStructure(); err == nil {
+			t.Errorf("%s: expected validation error", c.name)
+		}
+	}
+}
+
+func TestGetters(t *testing.T) {
+	tmpl := validTemplate()
+	tmpl.Version = "2.1.0"
+	tmpl.Content = []byte("body")
+	tmpl.Info.Tags = []string{"injection", "owasp"}
+	tmpl.Info.Description = "desc"
+	tmpl.Info.Author = "alice"
+
+	if tmpl.GetID() != "tmpl-1" || tmpl.GetName() != "Test Template" {
+		t.Fatal("GetID/GetName mismatch")
+	}
+	if tmpl.GetVersion() != "2.1.0" {
+		t.Fatalf("GetVersion = %q", tmpl.GetVersion())
+	}
+	if tmpl.GetSeverity() != "high" {
+		t.Fatalf("GetSeverity = %q", tmpl.GetSeverity())
+	}
+	if tmpl.GetCategory() != "injection" { // first tag
+		t.Fatalf("GetCategory = %q, want injection", tmpl.GetCategory())
+	}
+	if tmpl.GetDescription() != "desc" || tmpl.GetAuthor() != "alice" {
+		t.Fatal("GetDescription/GetAuthor mismatch")
+	}
+
+	body, err := tmpl.GetContent()
+	if err != nil || string(body) != "body" {
+		t.Fatalf("GetContent = %q, err=%v", body, err)
+	}
+}
+
+func TestGetters_Defaults(t *testing.T) {
+	// No Info, no tags -> category falls back to metadata then "general";
+	// severity falls back to "medium".
+	tmpl := &Template{ID: "x", Name: "n", Metadata: map[string]interface{}{}}
+	if tmpl.GetCategory() != "general" {
+		t.Fatalf("GetCategory default = %q, want general", tmpl.GetCategory())
+	}
+	if tmpl.GetSeverity() != "medium" {
+		t.Fatalf("GetSeverity default = %q, want medium", tmpl.GetSeverity())
+	}
+
+	// Category from metadata when no Info tags.
+	tmpl.Metadata["category"] = "jailbreak"
+	if tmpl.GetCategory() != "jailbreak" {
+		t.Fatalf("GetCategory from metadata = %q", tmpl.GetCategory())
+	}
+
+	// Empty content -> error.
+	if _, err := tmpl.GetContent(); err == nil {
+		t.Fatal("GetContent on empty content must error")
+	}
+}
+
+func TestGetReferences(t *testing.T) {
+	// []string form.
+	tmpl := &Template{Metadata: map[string]interface{}{"references": []string{"a", "b"}}}
+	if refs := tmpl.GetReferences(); len(refs) != 2 {
+		t.Fatalf("references []string = %v", refs)
+	}
+	// []interface{} form.
+	tmpl2 := &Template{Metadata: map[string]interface{}{"references": []interface{}{"x", "y", "z"}}}
+	if refs := tmpl2.GetReferences(); len(refs) != 3 {
+		t.Fatalf("references []interface{} = %v", refs)
+	}
+	// none.
+	if refs := (&Template{Metadata: map[string]interface{}{}}).GetReferences(); len(refs) != 0 {
+		t.Fatalf("no references should be empty, got %v", refs)
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	if _, err := LoadFromFile(filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
+		t.Fatal("LoadFromFile on missing path must error")
+	}
+
+	p := filepath.Join(t.TempDir(), "t.yaml")
+	if err := os.WriteFile(p, []byte("id: x\nname: y\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tmpl, err := LoadFromFile(p)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	if len(tmpl.Content) == 0 {
+		t.Fatal("loaded template should carry content")
+	}
+}
+
+func TestParseTemplate(t *testing.T) {
+	if _, err := ParseTemplate(nil); err == nil {
+		t.Fatal("ParseTemplate on empty content must error")
+	}
+	tmpl, err := ParseTemplate([]byte("some content"))
+	if err != nil {
+		t.Fatalf("ParseTemplate: %v", err)
+	}
+	if len(tmpl.Content) == 0 {
+		t.Fatal("parsed template should carry content")
+	}
+}
+
+func TestClone_DeepCopy(t *testing.T) {
+	orig := validTemplate()
+	orig.Content = []byte("data")
+	orig.Metadata = map[string]interface{}{"k": "v"}
+
+	clone := orig.Clone()
+	if clone.ID != orig.ID {
+		t.Fatal("clone should copy ID")
+	}
+	// Mutating the clone's copied maps/slices must not affect the original.
+	clone.Content[0] = 'X'
+	clone.Metadata["k"] = "changed"
+	if orig.Content[0] == 'X' {
+		t.Fatal("Clone must deep-copy Content")
+	}
+	if orig.Metadata["k"] != "v" {
+		t.Fatal("Clone must deep-copy Metadata")
+	}
+
+	// Clone of nil is nil.
+	var nilT *Template
+	if nilT.Clone() != nil {
+		t.Fatal("Clone of nil should be nil")
+	}
+}

--- a/src/template/management/cache/cache_test.go
+++ b/src/template/management/cache/cache_test.go
@@ -1,0 +1,197 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/template/format"
+)
+
+func tmpl(id string) *format.Template {
+	return &format.Template{ID: id, Name: "tmpl-" + id}
+}
+
+func TestNewTemplateCache_Defaults(t *testing.T) {
+	c := NewTemplateCache(0, 0, "")
+	stats := c.GetStats()
+	if stats["max_size"].(int) != 100 {
+		t.Errorf("default max_size = %v, want 100", stats["max_size"])
+	}
+	if stats["eviction_policy"].(string) != string(LRU) {
+		t.Errorf("default policy = %v, want lru", stats["eviction_policy"])
+	}
+	if stats["default_ttl_ms"].(int64) != time.Hour.Milliseconds() {
+		t.Errorf("default ttl = %v, want 1h", stats["default_ttl_ms"])
+	}
+}
+
+func TestCache_SetGetReadAfterWrite(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 10, LRU)
+	c.Set("a", tmpl("a"))
+
+	got, ok := c.Get("a")
+	if !ok || got.ID != "a" {
+		t.Fatalf("read-after-write failed: ok=%v got=%v", ok, got)
+	}
+	if _, ok := c.Get("missing"); ok {
+		t.Fatal("Get on missing id should be false")
+	}
+}
+
+func TestCache_Expiry(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 10, LRU)
+	c.SetWithTTL("a", tmpl("a"), 10*time.Millisecond)
+
+	time.Sleep(25 * time.Millisecond)
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("expired entry should not be returned")
+	}
+	// Get should have removed the expired entry.
+	if c.Size() != 0 {
+		t.Fatalf("expired entry should be evicted on Get, size=%d", c.Size())
+	}
+}
+
+func TestCache_DeleteClearSize(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 10, LRU)
+	c.Set("a", tmpl("a"))
+	c.Set("b", tmpl("b"))
+	if c.Size() != 2 {
+		t.Fatalf("size = %d, want 2", c.Size())
+	}
+	c.Delete("a")
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("deleted entry still present")
+	}
+	c.Clear()
+	if c.Size() != 0 {
+		t.Fatalf("size after clear = %d, want 0", c.Size())
+	}
+}
+
+func TestCache_Prune(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 10, LRU)
+	c.Set("fresh", tmpl("fresh"))
+	c.SetWithTTL("expired", tmpl("expired"), 1*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+
+	// Prune with a large maxAge removes only the already-expired entry.
+	removed := c.Prune(time.Hour)
+	if removed != 1 {
+		t.Fatalf("Prune removed %d, want 1", removed)
+	}
+	if _, ok := c.Get("fresh"); !ok {
+		t.Fatal("fresh entry should survive prune")
+	}
+}
+
+func TestCache_EvictLRU(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 2, LRU)
+	c.Set("a", tmpl("a"))
+	time.Sleep(2 * time.Millisecond)
+	c.Set("b", tmpl("b"))
+	// Touch "a" so "b" becomes least-recently-used.
+	time.Sleep(2 * time.Millisecond)
+	c.Get("a")
+	c.Set("c", tmpl("c")) // full -> evict LRU (b)
+
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("LRU should have evicted b")
+	}
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("a should remain after LRU eviction")
+	}
+}
+
+func TestCache_EvictLFU(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 2, LFU)
+	c.Set("a", tmpl("a"))
+	c.Set("b", tmpl("b"))
+	// Access "a" so "b" is least-frequently-used.
+	c.Get("a")
+	c.Get("a")
+	c.Set("c", tmpl("c")) // evict LFU (b)
+
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("LFU should have evicted b")
+	}
+}
+
+func TestCache_EvictFIFO(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 2, FIFO)
+	c.Set("a", tmpl("a"))
+	time.Sleep(2 * time.Millisecond)
+	c.Set("b", tmpl("b"))
+	// Even though "a" is accessed, FIFO evicts by creation order.
+	c.Get("a")
+	c.Set("c", tmpl("c")) // evict oldest-created (a)
+
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("FIFO should have evicted a (oldest created)")
+	}
+}
+
+func TestCache_SetMaxSizeShrinks(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 10, LRU)
+	for i := 0; i < 5; i++ {
+		c.Set(fmt.Sprintf("k%d", i), tmpl(fmt.Sprintf("k%d", i)))
+	}
+	c.SetMaxSize(2)
+	if c.Size() > 2 {
+		t.Fatalf("SetMaxSize should evict down to 2, size=%d", c.Size())
+	}
+	// Non-positive sizes are ignored.
+	c.SetMaxSize(0)
+	if c.GetStats()["max_size"].(int) != 2 {
+		t.Fatal("SetMaxSize(0) should be ignored")
+	}
+}
+
+func TestCache_RefreshAndKeys(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 10, LRU)
+	c.SetWithTTL("a", tmpl("a"), 10*time.Millisecond)
+
+	if !c.Refresh("a") {
+		t.Fatal("Refresh on existing entry should return true")
+	}
+	if c.Refresh("missing") {
+		t.Fatal("Refresh on missing entry should return false")
+	}
+	if !c.RefreshWithTTL("a", time.Hour) {
+		t.Fatal("RefreshWithTTL on existing entry should return true")
+	}
+	// After refresh with long TTL, the entry should outlive the original 10ms.
+	time.Sleep(20 * time.Millisecond)
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("refreshed entry should not have expired")
+	}
+
+	if len(c.GetKeys()) != 1 {
+		t.Fatalf("GetKeys = %v", c.GetKeys())
+	}
+}
+
+// TestCache_ConcurrentAccess exercises the RWMutex paths under -race.
+func TestCache_ConcurrentAccess(t *testing.T) {
+	c := NewTemplateCache(time.Hour, 1000, LRU)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				id := fmt.Sprintf("g%d-%d", g, i)
+				c.Set(id, tmpl(id))
+				c.Get(id)
+				if i%10 == 0 {
+					c.Size()
+					c.GetStats()
+					c.GetKeys()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/src/template/management/loader/loader_test.go
+++ b/src/template/management/loader/loader_test.go
@@ -1,0 +1,149 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/perplext/LLMrecon/src/template/format"
+	"github.com/perplext/LLMrecon/src/template/management/interfaces"
+)
+
+func newLoader() *TemplateLoader {
+	// repoManager is only needed for remote sources; nil is fine for local/parse.
+	return NewTemplateLoader(time.Hour, nil)
+}
+
+// parseTemplateFromContent is the real parser (format.LoadFromFile only reads
+// raw bytes). These cover the issue's parsing + error paths.
+func TestParseTemplateFromContent(t *testing.T) {
+	jsonTmpl, err := parseTemplateFromContent("t.json", []byte(`{"id":"json-id","name":"n"}`))
+	if err != nil {
+		t.Fatalf("parse JSON: %v", err)
+	}
+	if jsonTmpl.ID != "json-id" {
+		t.Fatalf("JSON ID = %q, want json-id", jsonTmpl.ID)
+	}
+
+	yamlTmpl, err := parseTemplateFromContent("t.yaml", []byte("id: yaml-id\nname: n\n"))
+	if err != nil {
+		t.Fatalf("parse YAML: %v", err)
+	}
+	if yamlTmpl.ID != "yaml-id" {
+		t.Fatalf("YAML ID = %q, want yaml-id", yamlTmpl.ID)
+	}
+}
+
+func TestParseTemplateFromContent_Errors(t *testing.T) {
+	// Malformed YAML.
+	if _, err := parseTemplateFromContent("t.yaml", []byte("id: [unclosed\n  : :")); err == nil {
+		t.Error("malformed YAML must error")
+	}
+	// Malformed JSON.
+	if _, err := parseTemplateFromContent("t.json", []byte("{not json")); err == nil {
+		t.Error("malformed JSON must error")
+	}
+	// Unsupported extension.
+	if _, err := parseTemplateFromContent("t.txt", []byte("whatever")); err == nil {
+		t.Error("unsupported extension must error")
+	}
+}
+
+func TestIsTemplateFile(t *testing.T) {
+	cases := map[string]bool{
+		"a.yaml": true, "a.yml": true, "a.json": true,
+		"a.txt": false, "a.go": false, "a": false,
+	}
+	for name, want := range cases {
+		if got := isTemplateFile(name); got != want {
+			t.Errorf("isTemplateFile(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	l := newLoader()
+	if _, err := l.Load(filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
+		t.Fatal("Load on missing file must error")
+	}
+}
+
+func TestLoad_ReadsExistingFile(t *testing.T) {
+	l := newLoader()
+	p := filepath.Join(t.TempDir(), "t.yaml")
+	if err := os.WriteFile(p, []byte("id: x\nname: y\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tmpl, err := l.Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// format.LoadFromFile reads raw bytes into Content (it does not deep-parse).
+	if len(tmpl.Content) == 0 {
+		t.Fatal("loaded template should carry file content")
+	}
+}
+
+func TestLoadTemplates_SourceRouting(t *testing.T) {
+	l := newLoader()
+	ctx := context.Background()
+
+	if _, err := l.LoadTemplates(ctx, filepath.Join(t.TempDir(), "missing"), string(interfaces.FileSource)); err == nil {
+		t.Error("missing FileSource path must error")
+	}
+	if _, err := l.LoadTemplates(ctx, "x", string(interfaces.GitLabSource)); err == nil {
+		t.Error("GitLab source should report not implemented")
+	}
+	if _, err := l.LoadTemplates(ctx, "x", string(interfaces.DatabaseSource)); err == nil {
+		t.Error("Database source should report not implemented")
+	}
+	if _, err := l.LoadTemplates(ctx, "x", "bogus-source"); err == nil {
+		t.Error("unsupported source type must error")
+	}
+}
+
+func TestLoadFromBytes_StubTemplate(t *testing.T) {
+	l := newLoader()
+	got, err := l.LoadFromBytes([]byte("anything"))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadFromBytes should return a template")
+	}
+
+	tmpl, err := l.LoadFromBytesWithFormat([]byte("data"), "yaml")
+	if err != nil || tmpl == nil {
+		t.Fatalf("LoadFromBytesWithFormat: tmpl=%v err=%v", tmpl, err)
+	}
+}
+
+func TestLoadFromURL_NotImplemented(t *testing.T) {
+	if _, err := newLoader().LoadFromURL("https://example.com/t.yaml"); err == nil {
+		t.Fatal("LoadFromURL should report not implemented")
+	}
+}
+
+func TestCacheMethods(t *testing.T) {
+	l := newLoader()
+
+	// Seed the internal cache directly (same package): one fresh, one expired.
+	l.cache["fresh"] = cacheEntry{template: &format.Template{ID: "fresh"}, expiration: time.Now().Add(time.Hour)}
+	l.cache["stale"] = cacheEntry{template: &format.Template{ID: "stale"}, expiration: time.Now().Add(-time.Hour)}
+
+	if l.GetCacheSize() != 2 {
+		t.Fatalf("GetCacheSize = %d, want 2", l.GetCacheSize())
+	}
+	if pruned := l.PruneCache(); pruned != 1 {
+		t.Fatalf("PruneCache removed %d, want 1 (the expired entry)", pruned)
+	}
+	if l.GetCacheSize() != 1 {
+		t.Fatalf("after prune size = %d, want 1", l.GetCacheSize())
+	}
+	l.ClearCache()
+	if l.GetCacheSize() != 0 {
+		t.Fatalf("after clear size = %d, want 0", l.GetCacheSize())
+	}
+}


### PR DESCRIPTION
## Summary

First tests for **`src/template/`** (76 files, previously **0 tests**) — the package powering the attack-data pipeline (loader → validator → cache). Per #229, the bar is the named target surface covered with happy + error paths, and `go test -race ./src/template/...` non-trivial.

3 test files, ~25 test functions, all green under `-race`.

## Acceptance (#229)
- ✅ `go test -race ./src/template/...` is non-trivial
- ✅ Covers the loader / validator / cache targets

## Coverage by target
| Target | Tests |
|--------|-------|
| `management/cache/cache.go` | read-after-write, TTL expiry, delete/clear/size, prune, **LRU/LFU/FIFO eviction**, SetMaxSize shrink, refresh, stats, **concurrent access (-race)** |
| `management/loader/loader.go` | `parseTemplateFromContent` happy + malformed YAML/JSON + unsupported ext; `isTemplateFile`; `Load` missing/existing; `LoadTemplates` source routing; `LoadFromBytes`; `LoadFromURL` not-implemented; cache prune/size/clear |
| `format/template.go` (validator) | `ValidateStructure` required-field checks (ID/Name/Info/Test); getters (category/severity/content/references…) + defaults; `LoadFromFile`; `ParseTemplate`; `Clone` deep-copy independence |

### Security/robustness highlights
- **Concurrency**: an 8-goroutine Set/Get/Stats stress test exercises the cache's `RWMutex` under `-race`.
- **Eviction correctness**: each policy (LRU/LFU/FIFO) is verified to evict the *right* entry, with small sleeps for deterministic timestamp ordering.

## Honest scoping note
`format.LoadFromFile` / `ParseTemplate` currently read raw bytes and stamp default `Info` rather than deep-parsing (`ParseTemplate` carries a `// TODO: Add actual parsing logic`). The real structured YAML/JSON parsing is `loader.parseTemplateFromContent`, which is what the parsing tests target. The broader `management/` subtree (registry, parser, execution, monitoring, …) remains a follow-up.

## Verification
- `go test ./src/template/... -race` — green (stable across `-count=10` on the time-based eviction tests).
- `go vet` — clean.

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9