### PR TITLE
feat(cmd): add --api-key flag to attack run (#234 part 1)

### DIFF
--- a/src/cmd/attack.go
+++ b/src/cmd/attack.go
@@ -40,6 +40,7 @@ var (
 	attackListJSON   bool
 	attackRunModule  string
 	attackRunProvider string
+	attackRunAPIKey  string
 	attackRunPayload string
 	attackRunMetadata []string
 	attackRunSuccessIndicators []string
@@ -103,6 +104,7 @@ func init() {
 
 	attackRunCmd.Flags().StringVar(&attackRunModule, "module", "", "registered module name (required)")
 	attackRunCmd.Flags().StringVar(&attackRunProvider, "provider", "mock", "provider name (currently: mock only)")
+	attackRunCmd.Flags().StringVar(&attackRunAPIKey, "api-key", "", "provider API key; takes precedence over the provider's *_API_KEY env var")
 	attackRunCmd.Flags().StringVar(&attackRunPayload, "payload", "", "operator-supplied payload (the harmful query, instruction, etc.)")
 	attackRunCmd.Flags().StringSliceVar(&attackRunMetadata, "metadata", nil, "key=value pair (repeatable; e.g. allow_experimental=true)")
 	attackRunCmd.Flags().StringSliceVar(&attackRunSuccessIndicators, "success-indicators", nil, "comma-separated substrings that mark Outcome=Success")
@@ -172,7 +174,7 @@ func runAttackRun(out, _ io.Writer) error {
 		return err
 	}
 
-	provider, err := buildAttackProvider(attackRunProvider)
+	provider, err := buildAttackProvider(attackRunProvider, attackRunAPIKey)
 	if err != nil {
 		return err
 	}
@@ -256,28 +258,30 @@ func writeJSONLEntry(target string, out io.Writer, provider common.Provider, res
 // buildAttackProvider constructs a common.Provider for the named provider.
 //
 //   - "mock" (default): runtime mock; deterministic refusal response.
-//   - "openai": real OpenAI adapter wrapped via bridge.WrapCore. Reads
-//     API key from OPENAI_API_KEY env var. Model from OPENAI_MODEL or
-//     defaults to "gpt-4o-mini".
-//   - "anthropic": real Anthropic adapter via bridge.WrapCore. Reads
-//     ANTHROPIC_API_KEY; model from ANTHROPIC_MODEL or defaults to
-//     "claude-3-5-sonnet-20241022".
+//   - "openai": real OpenAI adapter wrapped via bridge.WrapCore. API key
+//     from the apiKey arg (--api-key flag) if set, else OPENAI_API_KEY env
+//     var. Model from OPENAI_MODEL or defaults to "gpt-4o-mini".
+//   - "anthropic": real Anthropic adapter via bridge.WrapCore. API key from
+//     apiKey arg else ANTHROPIC_API_KEY; model from ANTHROPIC_MODEL or
+//     defaults to "claude-3-5-sonnet-20241022".
 //
-// Friendly errors when API keys are missing — distinct from the earlier
-// "not yet supported" stub the previous version emitted.
+// The apiKey argument (sourced from --api-key) takes precedence over the
+// provider's *_API_KEY env var. Friendly errors when no key is available —
+// distinct from the earlier "not yet supported" stub the previous version
+// emitted.
 //
 // Per-modality capability gates (ImageProvider, ReasoningProvider) come
 // online when the real-provider adapters are wired (#234); until then,
 // modules requiring those capabilities emit clean SkipMissingCapability
 // outcomes against real providers.
-func buildAttackProvider(name string) (common.Provider, error) {
+func buildAttackProvider(name, apiKey string) (common.Provider, error) {
 	switch name {
 	case "mock", "":
 		return &cmdMockProvider{}, nil
 	case "openai":
-		key := os.Getenv("OPENAI_API_KEY")
+		key := firstNonEmpty(apiKey, os.Getenv("OPENAI_API_KEY"))
 		if key == "" {
-			return nil, fmt.Errorf("provider=openai requires OPENAI_API_KEY env var")
+			return nil, fmt.Errorf("provider=openai requires an API key (--api-key flag or OPENAI_API_KEY env var)")
 		}
 		model := envOr("OPENAI_MODEL", "gpt-4o-mini")
 		cfg := &core.ProviderConfig{
@@ -291,9 +295,9 @@ func buildAttackProvider(name string) (common.Provider, error) {
 		}
 		return bridge.WrapCore(p), nil
 	case "anthropic":
-		key := os.Getenv("ANTHROPIC_API_KEY")
+		key := firstNonEmpty(apiKey, os.Getenv("ANTHROPIC_API_KEY"))
 		if key == "" {
-			return nil, fmt.Errorf("provider=anthropic requires ANTHROPIC_API_KEY env var")
+			return nil, fmt.Errorf("provider=anthropic requires an API key (--api-key flag or ANTHROPIC_API_KEY env var)")
 		}
 		model := envOr("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
 		cfg := &core.ProviderConfig{
@@ -317,6 +321,17 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// firstNonEmpty returns the first non-empty string, or "" if all are empty.
+// Used so the --api-key flag takes precedence over the *_API_KEY env var.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // cmdMockProvider is a runtime mock for `attack run --provider=mock`.

--- a/src/cmd/attack_test.go
+++ b/src/cmd/attack_test.go
@@ -170,7 +170,7 @@ func TestRunAttackRun_RejectsUnknownProvider(t *testing.T) {
 // error when OPENAI_API_KEY env var is unset.
 func TestBuildAttackProvider_OpenAIRequiresAPIKey(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
-	_, err := buildAttackProvider("openai")
+	_, err := buildAttackProvider("openai", "")
 	if err == nil {
 		t.Fatal("expected error when OPENAI_API_KEY is unset")
 	}
@@ -183,7 +183,7 @@ func TestBuildAttackProvider_OpenAIRequiresAPIKey(t *testing.T) {
 // error for Anthropic.
 func TestBuildAttackProvider_AnthropicRequiresAPIKey(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	_, err := buildAttackProvider("anthropic")
+	_, err := buildAttackProvider("anthropic", "")
 	if err == nil {
 		t.Fatal("expected error when ANTHROPIC_API_KEY is unset")
 	}
@@ -197,7 +197,7 @@ func TestBuildAttackProvider_AnthropicRequiresAPIKey(t *testing.T) {
 // end-to-end). No API call fires; this is the type-level wiring check.
 func TestBuildAttackProvider_OpenAIWrapsViaBridge(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-test-fake-key-not-used")
-	p, err := buildAttackProvider("openai")
+	p, err := buildAttackProvider("openai", "")
 	if err != nil {
 		t.Fatalf("buildAttackProvider: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestBuildAttackProvider_OpenAIWrapsViaBridge(t *testing.T) {
 // TestBuildAttackProvider_AnthropicWrapsViaBridge — parallel for Anthropic.
 func TestBuildAttackProvider_AnthropicWrapsViaBridge(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-fake-key-not-used")
-	p, err := buildAttackProvider("anthropic")
+	p, err := buildAttackProvider("anthropic", "")
 	if err != nil {
 		t.Fatalf("buildAttackProvider: %v", err)
 	}
@@ -233,6 +233,44 @@ func TestEnvOr(t *testing.T) {
 	t.Setenv("TEST_KEY_ABSENT", "")
 	if got := envOr("TEST_KEY_ABSENT", "fallback"); got != "fallback" {
 		t.Errorf("envOr absent = %q, want fallback", got)
+	}
+}
+
+// TestFirstNonEmpty covers the precedence helper backing --api-key: the flag
+// value (first arg) must win over the env value (second arg).
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("flag", "env"); got != "flag" {
+		t.Errorf("flag should win: got %q", got)
+	}
+	if got := firstNonEmpty("", "env"); got != "env" {
+		t.Errorf("env should be used when flag empty: got %q", got)
+	}
+	if got := firstNonEmpty("", ""); got != "" {
+		t.Errorf("both empty should be empty: got %q", got)
+	}
+}
+
+// TestBuildAttackProvider_APIKeyFlag asserts the --api-key flag value is honored
+// as the key source even when the provider's env var is unset (#234).
+func TestBuildAttackProvider_APIKeyFlag(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "") // env empty; only the flag supplies the key
+	p, err := buildAttackProvider("openai", "sk-flag-supplied-key")
+	if err != nil {
+		t.Fatalf("--api-key should satisfy the key requirement: %v", err)
+	}
+	if p == nil || p.GetName() != "openai" {
+		t.Fatalf("expected wired openai provider, got %v", p)
+	}
+
+	// With neither flag nor env, construction fails with a friendly error that
+	// names both sources.
+	_, err = buildAttackProvider("anthropic", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	if _, err = buildAttackProvider("anthropic", ""); err == nil {
+		t.Fatal("expected error when neither --api-key nor env var is set")
+	}
+	if !strings.Contains(err.Error(), "--api-key") {
+		t.Errorf("error should mention the --api-key flag; got %q", err.Error())
 	}
 }
 

--- a/src/cmd/attack_test.go
+++ b/src/cmd/attack_test.go
@@ -264,7 +264,6 @@ func TestBuildAttackProvider_APIKeyFlag(t *testing.T) {
 
 	// With neither flag nor env, construction fails with a friendly error that
 	// names both sources.
-	_, err = buildAttackProvider("anthropic", "")
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	if _, err = buildAttackProvider("anthropic", ""); err == nil {
 		t.Fatal("expected error when neither --api-key nor env var is set")


### PR DESCRIPTION
## Summary

**Part 1 of #234.** The OpenAI/Anthropic provider wiring (`bridge.WrapCore`) was already in place, but API keys could only come from `*_API_KEY` env vars — the `--api-key` flag was promised in help text yet never registered.

## Change
- Register `--api-key` on `attack run`.
- `buildAttackProvider(name, apiKey)`: the flag value takes precedence over the provider's env var (via a small `firstNonEmpty` helper). When neither is set, the error names **both** sources (`--api-key flag or OPENAI_API_KEY env var`).
- Refresh the now-stale doc comment.

## Tests
- `firstNonEmpty` precedence (flag beats env)
- `--api-key` honored with the env var unset
- no-key error mentions the `--api-key` flag
- existing env-based provider tests updated for the new signature

## Acceptance status (#234)
- ✅ `--api-key` flag works and takes precedence over env vars
- ⬜ **Remaining (Part 2, own PR):** the failure-mode httptest matrix — missing key → `SkipPreconditionFailed`; rate-limit retry → `SkipProviderError`; content-policy → `OutcomeRefused`; H-CoT vs Anthropic → `SkipSignatureGated` — each asserting `SkipReason` by name. That's an integration-test effort across the module/provider error-mapping layer; scoped separately to keep this PR focused and mergeable.

## Verification
- `go build ./...`, `go vet ./src/cmd/`, `go test ./src/cmd/` — all clean.

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--api-key` flag to the `attack run` command, enabling direct API key specification
  * Flag value takes precedence over corresponding environment variables
  * Updated error messages to reference the new `--api-key` option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->