### PR TITLE
test(provider): document openai/anthropic HTTP error classification (#234 part 2)

### DIFF
--- a/src/provider/anthropic/failure_modes_test.go
+++ b/src/provider/anthropic/failure_modes_test.go
@@ -1,0 +1,73 @@
+package anthropic
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// dummyProvider returns an AnthropicProvider instance for exercising the
+// error-classification method. The base URL points at a closed server because
+// handleErrorResponse performs no I/O.
+func dummyProvider(t *testing.T) *AnthropicProvider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	return newTestProvider(t, srv)
+}
+
+// TestHandleErrorResponse_Classification documents how the Anthropic provider
+// maps non-200 statuses: each surfaces as a *core.ProviderError carrying the
+// HTTP status code, for both well-formed and malformed error bodies. We call
+// handleErrorResponse directly because ChatCompletion's HTTP path is wrapped by
+// the circuit breaker (a separate resilience layer) with no raw entry point.
+func TestHandleErrorResponse_Classification(t *testing.T) {
+	p := dummyProvider(t)
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"rate_limit", http.StatusTooManyRequests, `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`},
+		{"unauthorized", http.StatusUnauthorized, `{"type":"error","error":{"type":"authentication_error","message":"bad key"}}`},
+		{"bad_request", http.StatusBadRequest, `{"type":"error","error":{"type":"invalid_request_error","message":"bad"}}`},
+		{"server_error", http.StatusInternalServerError, `{"type":"error","error":{"type":"api_error","message":"oops"}}`},
+		{"malformed_body", http.StatusServiceUnavailable, `not-json`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := p.handleErrorResponse(c.status, []byte(c.body))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			var pe *core.ProviderError
+			if !errors.As(err, &pe) {
+				t.Fatalf("expected *core.ProviderError, got %T: %v", err, err)
+			}
+			if pe.StatusCode != c.status {
+				t.Errorf("StatusCode = %d, want %d", pe.StatusCode, c.status)
+			}
+		})
+	}
+}
+
+// TestHandleErrorResponse_RateLimitNotYetRetryable documents the same wiring gap
+// as the OpenAI provider: a 429 surfaces as a *core.ProviderError, which
+// core.IsTransient does not recognize, so RetryableQuery would not retry it.
+// Flip this assertion when the provider→retry classification is implemented.
+func TestHandleErrorResponse_RateLimitNotYetRetryable(t *testing.T) {
+	p := dummyProvider(t)
+	err := p.handleErrorResponse(http.StatusTooManyRequests, []byte(`{"error":{"type":"rate_limit_error"}}`))
+	if err == nil {
+		t.Fatal("expected an error for 429")
+	}
+	if core.IsTransient(err) {
+		t.Error("429 is now transient — retry wiring implemented; update this test and close the gap issue")
+	}
+	if core.IsPermanent(err) {
+		t.Error("429 is now permanent — revisit: a rate limit should be transient")
+	}
+}

--- a/src/provider/openai/failure_modes_test.go
+++ b/src/provider/openai/failure_modes_test.go
@@ -1,0 +1,88 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/provider/core"
+)
+
+// errorServer returns an httptest server that always replies with the given
+// HTTP status and body — used to drive the provider's error-classification path.
+func errorServer(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func chatReq() *core.ChatCompletionRequest {
+	return &core.ChatCompletionRequest{
+		Messages: []core.Message{{Role: "user", Content: "hello"}},
+	}
+}
+
+// TestChatCompletionFromAPI_ErrorClassification documents how the OpenAI
+// provider maps non-200 HTTP responses: every failure surfaces as a
+// *core.ProviderError carrying the HTTP status code, for both well-formed and
+// malformed error bodies. We exercise chatCompletionFromAPI (the raw HTTP path)
+// directly rather than ChatCompletion, because the latter's circuit breaker
+// retries 5xx/429 and then returns an opaque "circuit breaker is open" error —
+// a separate resilience layer from the error-classification under test here.
+func TestChatCompletionFromAPI_ErrorClassification(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"rate_limit", http.StatusTooManyRequests, `{"error":{"message":"rate limit reached","type":"rate_limit_error","code":"rate_limited"}}`},
+		{"unauthorized", http.StatusUnauthorized, `{"error":{"message":"invalid api key","type":"invalid_request_error","code":"invalid_api_key"}}`},
+		{"bad_request", http.StatusBadRequest, `{"error":{"message":"bad input","type":"invalid_request_error"}}`},
+		{"server_error", http.StatusInternalServerError, `{"error":{"message":"internal"}}`},
+		{"malformed_body", http.StatusServiceUnavailable, `not-json-at-all`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := errorServer(c.status, c.body)
+			defer srv.Close()
+			p := newTestProvider(t, srv)
+
+			_, err := p.chatCompletionFromAPI(context.Background(), chatReq())
+			if err == nil {
+				t.Fatal("expected an error for non-200 response")
+			}
+			var pe *core.ProviderError
+			if !errors.As(err, &pe) {
+				t.Fatalf("expected *core.ProviderError in chain, got %T: %v", err, err)
+			}
+			if pe.StatusCode != c.status {
+				t.Errorf("StatusCode = %d, want %d", pe.StatusCode, c.status)
+			}
+		})
+	}
+}
+
+// TestChatCompletionFromAPI_RateLimitNotYetRetryable documents a current wiring
+// gap (tracked separately): a 429 surfaces as a *core.ProviderError, which
+// core.IsTransient does NOT recognize, so the RetryableQuery helper would treat
+// it as non-retryable. When the provider→retry classification is implemented,
+// this assertion will flip and should be updated alongside closing the gap.
+func TestChatCompletionFromAPI_RateLimitNotYetRetryable(t *testing.T) {
+	srv := errorServer(http.StatusTooManyRequests, `{"error":{"message":"slow down","type":"rate_limit_error"}}`)
+	defer srv.Close()
+	p := newTestProvider(t, srv)
+
+	_, err := p.chatCompletionFromAPI(context.Background(), chatReq())
+	if err == nil {
+		t.Fatal("expected an error for 429")
+	}
+	if core.IsTransient(err) {
+		t.Error("429 is now classified as transient — the retry wiring was implemented; update this test and close the gap issue")
+	}
+	if core.IsPermanent(err) {
+		t.Error("429 is now classified as permanent — revisit: a rate limit should be transient")
+	}
+}


### PR DESCRIPTION
## Summary

**Part 2 of #234**, per the agreed test-only scope. Adds failure-mode coverage for the wired providers' HTTP error classification, and documents a real wiring gap found while scoping it.

## What this adds
- **openai/failure_modes_test.go** — drives `chatCompletionFromAPI` against an httptest server returning **429 / 401 / 400 / 5xx** and a **malformed body**, asserting each surfaces as a `*core.ProviderError` carrying the HTTP status code.
- **anthropic/failure_modes_test.go** — same matrix via `handleErrorResponse` directly.

Why not the public `ChatCompletion`? Both providers wrap it in `executeWithResilience` (a circuit breaker that retries 5xx/429 and then returns an opaque `"circuit breaker is open"` string, masking the typed error). Testing the classifier directly is deterministic and tests the logic under question.

## Wiring gap discovered → filed as #304
While tracing #234's scenario 2 (rate-limit → retry → `SkipProviderError`), I found the chain **isn't wired in production**:
- Providers return `*core.ProviderError`, never `*TransientError`/`*PermanentError`.
- `core.IsTransient`/`IsPermanent` only match the typed errors → a 429 is "unknown → no retry."
- `RetryableQuery` has **zero production callers**; `*TransientError{}` is never constructed outside tests.

Each provider's `*NotYetRetryable` test pins this current behavior and will flip when #304 is fixed.

## Why #234's other scenarios are already covered
- **Module-outcome mapping** (`SkipPreconditionFailed`, `SkipSignatureGated`, `SkipProviderError`, `OutcomeRefused`) — already asserted by name in `src/attacks/reasoning/h_cot_test.go`.
- **Retry/backoff mechanics** — already covered by `src/provider/core/retry_test.go`.
- **`--api-key` flag** — landed in #303 (part 1).

So #234's acceptance is met across existing + these tests, with the genuine remaining work (provider→retry classification) tracked in #304.

## Verification
- `go test ./src/provider/openai/ ./src/provider/anthropic/ -run '...ErrorResponse|...ErrorClassification|...NotYetRetryable'` — green
- `go vet`, `go build ./...` — clean

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9