### PR TITLE
feat(attacks): Purger interface + attack purge for memory-implant cleanup (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This changelog was started with v0.9.0; earlier history lives in `git log`.
 
 ## [Unreleased]
 
+### Added
+
+- **`common.Purger` provider interface + `attack purge` command (#168).**
+  Automated cleanup of memory-poisoning implants, succeeding v0.9.0's manual
+  `CleanupHint` workflow. Providers that own a purgeable memory store implement
+  `Purger.Purge(ctx, recordIDs)`; the memory-poisoning modules (`minja`,
+  `memorygraft`, `injecmem`) now report `purger_available` in their result
+  metadata, and `llmrecon attack purge --provider <name> --record-ids <ids>`
+  (or `--result <emit-jsonl-file>`) rolls back the injection. Providers without
+  the capability get a friendly error pointing back to the manual `CleanupHint`.
+  Includes an in-memory reference `Purger` (`testutil.MockMemoryProvider`) and an
+  inject→verify-present→purge→verify-absent smoke test.
+
 ## [0.10.0] - 2026-05-03
 
 The v0.10.0 release is **the honesty release**. Every code path that

--- a/src/attacks/common/capabilities.go
+++ b/src/attacks/common/capabilities.go
@@ -122,6 +122,20 @@ type Cleaner interface {
 	Cleanup(ctx context.Context, recordIDs []string) error
 }
 
+// Purger is implemented by providers that own a memory store the operator can
+// purge programmatically. After a memory-poisoning run emits a CleanupHint with
+// injected record IDs (also recorded in result.Metadata["injected_record_ids"]),
+// the CLI (`llmrecon attack purge`) calls Purge to roll back the injection —
+// the automated successor to v0.9.0's manual-cleanup CleanupHint workflow.
+//
+// Modules type-assert against Purger to report whether a target supports
+// automated cleanup; the CLI type-asserts to perform it. Purge SHOULD be
+// idempotent: purging an already-absent ID is not an error.
+type Purger interface {
+	Provider
+	Purge(ctx context.Context, recordIDs []string) error
+}
+
 // ---------------------------------------------------------------------------
 // v0.10.0 #176 — modality-specific capabilities for agentic + audio attacks
 // ---------------------------------------------------------------------------

--- a/src/attacks/memory/poisoning.go
+++ b/src/attacks/memory/poisoning.go
@@ -266,6 +266,11 @@ func (m *MemoryPoisoningModule) Execute(
 	}
 	result.Metadata["injected_record_ids"] = []string{injectedID}
 	result.Metadata["mode"] = m.Mode
+	// Report whether the target supports automated cleanup (#168). When true,
+	// `llmrecon attack purge` can roll back the injection via Purger.Purge;
+	// otherwise the operator follows the manual CleanupHint.
+	_, purgerAvailable := provider.(common.Purger)
+	result.Metadata["purger_available"] = purgerAvailable
 
 	if matched {
 		result.Outcome = common.OutcomeSuccess

--- a/src/attacks/memory/purge_test.go
+++ b/src/attacks/memory/purge_test.go
@@ -1,0 +1,80 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/attacks/common"
+	"github.com/perplext/LLMrecon/src/attacks/testutil"
+)
+
+// TestMemoryPoisoning_PurgeRoundTrip is the #168 acceptance smoke test:
+// inject via the minja module against a Purger-capable mock, verify the implant
+// is present, purge via Purger, verify it's absent (and that re-purge is a no-op).
+func TestMemoryPoisoning_PurgeRoundTrip(t *testing.T) {
+	mock := testutil.NewMockMemoryProvider("ok")
+	mod := &MemoryPoisoningModule{Mode: modeMINJA}
+
+	res, err := mod.Execute(context.Background(), mock, gatedConfig("inject-this-secret"))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Outcome == common.OutcomeSkipped {
+		t.Fatalf("module skipped unexpectedly: reason=%s detail=%s", res.SkipReason, res.SkipDetail)
+	}
+
+	// The mock implements Purger, so the module must report it.
+	if res.Metadata["purger_available"] != true {
+		t.Fatalf("purger_available = %v, want true", res.Metadata["purger_available"])
+	}
+
+	ids, ok := res.Metadata["injected_record_ids"].([]string)
+	if !ok || len(ids) == 0 {
+		t.Fatalf("no injected_record_ids in metadata: %v", res.Metadata["injected_record_ids"])
+	}
+
+	// Implant present after injection.
+	for _, id := range ids {
+		if !mock.Has(id) {
+			t.Fatalf("implant %q not present after injection", id)
+		}
+	}
+
+	// Purge → absent.
+	if err := mock.Purge(context.Background(), ids); err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+	for _, id := range ids {
+		if mock.Has(id) {
+			t.Fatalf("implant %q still present after purge", id)
+		}
+	}
+
+	// Idempotent: purging an already-absent ID is a no-op.
+	if err := mock.Purge(context.Background(), ids); err != nil {
+		t.Fatalf("re-purge should be a no-op, got: %v", err)
+	}
+}
+
+// TestMemoryPoisoning_PurgerUnavailable: when the target implements MemoryProbe
+// but NOT Purger, the module reports purger_available=false (operator falls
+// back to the manual CleanupHint).
+func TestMemoryPoisoning_PurgerUnavailable(t *testing.T) {
+	// memoryAwareMock (from poisoning_test.go) implements MemoryProbe but not Purger.
+	provider := &memoryAwareMock{
+		MockProvider: &testutil.MockProvider{DefaultResponse: "ok"},
+		ProbeRetains: true,
+	}
+	mod := &MemoryPoisoningModule{Mode: modeMINJA}
+
+	res, err := mod.Execute(context.Background(), provider, gatedConfig("topic"))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Outcome == common.OutcomeSkipped {
+		t.Fatalf("module skipped unexpectedly: reason=%s", res.SkipReason)
+	}
+	if res.Metadata["purger_available"] != false {
+		t.Fatalf("purger_available = %v, want false (provider is not a Purger)", res.Metadata["purger_available"])
+	}
+}

--- a/src/attacks/testutil/memory_provider.go
+++ b/src/attacks/testutil/memory_provider.go
@@ -1,0 +1,82 @@
+package testutil
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/perplext/LLMrecon/src/attacks/common"
+)
+
+// MockMemoryProvider is a stateful provider for exercising the #168 cleanup
+// loop. It records the content of every prompt it receives (its "memory
+// store") and implements common.MemoryProbe (so memory-poisoning modules
+// proceed past their capability gate) and common.Purger (so the implant can be
+// rolled back). It is the in-memory reference Purger from #168's acceptance.
+type MockMemoryProvider struct {
+	*MockProvider
+
+	mu    sync.Mutex
+	store []string // recorded prompt contents — the simulated memory
+}
+
+// NewMockMemoryProvider returns a stateful memory provider whose plain Query
+// responses default to defaultResponse.
+func NewMockMemoryProvider(defaultResponse string) *MockMemoryProvider {
+	return &MockMemoryProvider{
+		MockProvider: &MockProvider{DefaultResponse: defaultResponse},
+	}
+}
+
+// Query records each message's content into the store, then delegates to the
+// embedded MockProvider for the response.
+func (m *MockMemoryProvider) Query(ctx context.Context, messages []common.Message, options map[string]interface{}) (string, error) {
+	m.mu.Lock()
+	for _, msg := range messages {
+		m.store = append(m.store, msg.Content)
+	}
+	m.mu.Unlock()
+	return m.MockProvider.Query(ctx, messages, options)
+}
+
+// ProbeMemory reports the target retains memory (it's a stateful store). It
+// returns true regardless of current contents — the probe is a capability
+// statement, not a "has records right now" check.
+func (m *MockMemoryProvider) ProbeMemory(_ context.Context) (bool, error) {
+	return true, nil
+}
+
+// Purge drops every stored entry that contains any of the given record IDs.
+// Idempotent: purging an absent ID is a no-op, not an error.
+func (m *MockMemoryProvider) Purge(_ context.Context, recordIDs []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	kept := make([]string, 0, len(m.store))
+	for _, entry := range m.store {
+		drop := false
+		for _, id := range recordIDs {
+			if id != "" && strings.Contains(entry, id) {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			kept = append(kept, entry)
+		}
+	}
+	m.store = kept
+	return nil
+}
+
+// Has reports whether any stored entry contains the given record ID — used by
+// tests to assert an implant is present or absent.
+func (m *MockMemoryProvider) Has(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, entry := range m.store {
+		if strings.Contains(entry, id) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/cmd/attack.go
+++ b/src/cmd/attack.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -45,6 +46,11 @@ var (
 	attackRunMetadata []string
 	attackRunSuccessIndicators []string
 	attackRunEmitJSONL string
+
+	attackPurgeProvider  string
+	attackPurgeAPIKey    string
+	attackPurgeRecordIDs []string
+	attackPurgeResult    string
 )
 
 var attackCmd = &cobra.Command{
@@ -95,10 +101,35 @@ Examples:
 	},
 }
 
+var attackPurgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Roll back a memory-poisoning injection via the provider's Purger",
+	Long: `Automated cleanup (#168) for memory-poisoning runs. The minja /
+memorygraft / injecmem modules record the injected record IDs in their result
+(metadata "injected_record_ids", also echoed in CleanupHint). This command
+calls Purger.Purge on the target to remove them — the successor to v0.9.0's
+manual-cleanup workflow.
+
+The provider must implement common.Purger (own a purgeable memory store);
+otherwise this reports a friendly error and you fall back to manual cleanup.
+
+Examples:
+
+  # Purge explicit record IDs
+  llmrecon attack purge --provider=mock --record-ids=rec-1,rec-2
+
+  # Purge IDs read from a prior run's --emit-jsonl output
+  llmrecon attack purge --provider=mock --result=run.jsonl`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runAttackPurge(cmd.OutOrStdout())
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(attackCmd)
 	attackCmd.AddCommand(attackListCmd)
 	attackCmd.AddCommand(attackRunCmd)
+	attackCmd.AddCommand(attackPurgeCmd)
 
 	attackListCmd.Flags().BoolVar(&attackListJSON, "json", false, "emit machine-readable JSON")
 
@@ -112,6 +143,11 @@ func init() {
 	if err := attackRunCmd.MarkFlagRequired("module"); err != nil {
 		panic(fmt.Sprintf("MarkFlagRequired: %v", err))
 	}
+
+	attackPurgeCmd.Flags().StringVar(&attackPurgeProvider, "provider", "mock", "provider name (must implement Purger)")
+	attackPurgeCmd.Flags().StringVar(&attackPurgeAPIKey, "api-key", "", "provider API key; takes precedence over the provider's *_API_KEY env var")
+	attackPurgeCmd.Flags().StringSliceVar(&attackPurgeRecordIDs, "record-ids", nil, "comma-separated injected record IDs to purge")
+	attackPurgeCmd.Flags().StringVar(&attackPurgeResult, "result", "", "path to a prior --emit-jsonl result file; reads injected_record_ids from it")
 }
 
 // ---------------------------------------------------------------------------
@@ -208,6 +244,91 @@ func runAttackRun(out, _ io.Writer) error {
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
 	return enc.Encode(result)
+}
+
+// ---------------------------------------------------------------------------
+// `attack purge`  (#168)
+// ---------------------------------------------------------------------------
+
+func runAttackPurge(out io.Writer) error {
+	// Gather the record IDs from --record-ids and/or a prior --result file.
+	ids := append([]string{}, attackPurgeRecordIDs...)
+	if attackPurgeResult != "" {
+		fromFile, err := readInjectedRecordIDs(attackPurgeResult)
+		if err != nil {
+			return fmt.Errorf("reading --result %s: %w", attackPurgeResult, err)
+		}
+		ids = append(ids, fromFile...)
+	}
+	ids = dedupeNonEmpty(ids)
+	if len(ids) == 0 {
+		return fmt.Errorf("no record IDs to purge; pass --record-ids or --result")
+	}
+
+	provider, err := buildAttackProvider(attackPurgeProvider, attackPurgeAPIKey)
+	if err != nil {
+		return err
+	}
+
+	purger, ok := provider.(common.Purger)
+	if !ok {
+		return fmt.Errorf("provider %q does not support automated purge (no Purger capability); "+
+			"follow the run's CleanupHint to remove the records manually", attackPurgeProvider)
+	}
+
+	if err := purger.Purge(context.Background(), ids); err != nil {
+		return fmt.Errorf("purge failed: %w", err)
+	}
+	fmt.Fprintf(out, "Purged %d record(s) from provider %q: %s\n", len(ids), attackPurgeProvider, strings.Join(ids, ", "))
+	return nil
+}
+
+// readInjectedRecordIDs reads injected_record_ids from each JSONL line of a
+// prior `--emit-jsonl` result file.
+func readInjectedRecordIDs(path string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- operator-supplied result path by design
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry jsonlEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, fmt.Errorf("parse JSONL line: %w", err)
+		}
+		if entry.Result == nil || entry.Result.Metadata == nil {
+			continue
+		}
+		// JSON unmarshals a []string into []interface{}.
+		switch v := entry.Result.Metadata["injected_record_ids"].(type) {
+		case []interface{}:
+			for _, item := range v {
+				if s, ok := item.(string); ok {
+					ids = append(ids, s)
+				}
+			}
+		case []string:
+			ids = append(ids, v...)
+		}
+	}
+	return ids, nil
+}
+
+func dedupeNonEmpty(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	var out []string
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
 }
 
 // jsonlEntry is the wire format for `--emit-jsonl`. Wraps an
@@ -347,3 +468,8 @@ func (cmdMockProvider) Query(_ context.Context, _ []common.Message, _ map[string
 func (cmdMockProvider) GetName() string             { return "mock" }
 func (cmdMockProvider) GetModel() string            { return "mock-model" }
 func (cmdMockProvider) GetTokenCount(s string) int  { return len(s) / 4 }
+
+// Purge implements common.Purger so `attack purge --provider=mock` exercises
+// the cleanup path end-to-end. The mock owns no real memory store, so purge is
+// a successful no-op.
+func (cmdMockProvider) Purge(_ context.Context, _ []string) error { return nil }

--- a/src/cmd/attack_test.go
+++ b/src/cmd/attack_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -331,4 +334,111 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// ---------------------------------------------------------------------------
+// `attack purge` (#168)
+// ---------------------------------------------------------------------------
+
+func TestAttackPurge_MockSucceeds(t *testing.T) {
+	attackPurgeProvider = "mock"
+	attackPurgeAPIKey = ""
+	attackPurgeRecordIDs = []string{"rec-1", "rec-2"}
+	attackPurgeResult = ""
+
+	var buf bytes.Buffer
+	if err := runAttackPurge(&buf); err != nil {
+		t.Fatalf("runAttackPurge: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Purged 2 record(s)") {
+		t.Errorf("unexpected output: %q", buf.String())
+	}
+}
+
+func TestAttackPurge_NoIDsErrors(t *testing.T) {
+	attackPurgeProvider = "mock"
+	attackPurgeAPIKey = ""
+	attackPurgeRecordIDs = nil
+	attackPurgeResult = ""
+
+	if err := runAttackPurge(io.Discard); err == nil {
+		t.Fatal("expected an error when no record IDs are supplied")
+	}
+}
+
+func TestAttackPurge_ProviderNotPurger(t *testing.T) {
+	// openai provider builds with a fake key (no network) but is not a Purger.
+	attackPurgeProvider = "openai"
+	attackPurgeAPIKey = "sk-fake-not-used"
+	attackPurgeRecordIDs = []string{"rec-1"}
+	attackPurgeResult = ""
+
+	err := runAttackPurge(io.Discard)
+	if err == nil {
+		t.Fatal("expected an error for a non-Purger provider")
+	}
+	if !strings.Contains(err.Error(), "does not support automated purge") {
+		t.Errorf("error should explain the missing Purger capability; got %v", err)
+	}
+}
+
+func TestAttackPurge_FromResultFile(t *testing.T) {
+	entry := jsonlEntry{
+		Provider: "mock",
+		Model:    "mock-model",
+		Result: &common.AttackResult{
+			Metadata: map[string]interface{}{"injected_record_ids": []string{"rec-from-file"}},
+		},
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	if err := os.WriteFile(path, append(line, '\n'), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	attackPurgeProvider = "mock"
+	attackPurgeAPIKey = ""
+	attackPurgeRecordIDs = nil
+	attackPurgeResult = path
+
+	var buf bytes.Buffer
+	if err := runAttackPurge(&buf); err != nil {
+		t.Fatalf("runAttackPurge: %v", err)
+	}
+	if !strings.Contains(buf.String(), "rec-from-file") {
+		t.Errorf("output should name the purged ID; got %q", buf.String())
+	}
+}
+
+func TestReadInjectedRecordIDs(t *testing.T) {
+	withIDs, _ := json.Marshal(jsonlEntry{Result: &common.AttackResult{
+		Metadata: map[string]interface{}{"injected_record_ids": []string{"a", "b"}},
+	}})
+	noMeta, _ := json.Marshal(jsonlEntry{Result: &common.AttackResult{}})
+	path := filepath.Join(t.TempDir(), "r.jsonl")
+	if err := os.WriteFile(path, []byte(string(withIDs)+"\n"+string(noMeta)+"\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	ids, err := readInjectedRecordIDs(path)
+	if err != nil {
+		t.Fatalf("readInjectedRecordIDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "a" || ids[1] != "b" {
+		t.Fatalf("ids = %v, want [a b]", ids)
+	}
+
+	if _, err := readInjectedRecordIDs(filepath.Join(t.TempDir(), "missing.jsonl")); err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestDedupeNonEmpty(t *testing.T) {
+	got := dedupeNonEmpty([]string{"a", "", "a", "b", ""})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("dedupeNonEmpty = %v, want [a b]", got)
+	}
 }


### PR DESCRIPTION
## Summary

First v0.12.0 feature. Automated cleanup of memory-poisoning implants — the successor to v0.9.0's manual `CleanupHint` workflow.

## Changes

### `common.Purger` interface
```go
type Purger interface {
    Provider
    Purge(ctx context.Context, recordIDs []string) error
}
```
Implemented by providers that own a purgeable memory store. Idempotent by contract.

### Modules report the capability
`minja` / `memorygraft` / `injecmem` type-assert the target against `Purger` and record `purger_available` in result metadata, alongside the existing `injected_record_ids`.

### `llmrecon attack purge`
Builds the provider, type-asserts `Purger`, and calls `Purge` with:
- `--record-ids id1,id2` (explicit), and/or
- `--result <emit-jsonl file>` (reads `injected_record_ids` from a prior `attack run --emit-jsonl`).

Providers without the capability get a friendly error pointing back to the manual `CleanupHint`.

### Reference implementations
- `testutil.MockMemoryProvider` — in-memory `Purger` + `MemoryProbe` that records injected prompts (the acceptance's "in-memory mock that implements Purger").
- `cmdMockProvider` implements `Purger` (no-op) so `attack purge --provider=mock` works end-to-end.

## Acceptance criteria (#168)
- [x] `common.Purger` interface added
- [x] Memory-poisoning modules report `Purger` capability presence in result metadata
- [x] CLI command invokes `Purger` with the recorded record IDs
- [x] At least one provider adapter (in-memory mock) implements `Purger`
- [x] Integration smoke test: inject → verify present → purge → verify absent
- [x] CHANGELOG entry under `[Unreleased]`

## Tests
`memory` smoke test (inject→present→purge→absent + idempotent re-purge + purger_available true/false); CLI happy / no-ids / non-Purger / from-result-file; `readInjectedRecordIDs` + `dedupeNonEmpty` units. All green under `-race`.

Closes #168.

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9