### PR TITLE
feat(adaptive): MCTS-Explore selection strategy for jbfuzz (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This changelog was started with v0.9.0; earlier history lives in `git log`.
 
 ### Added
 
+- **MCTS-Explore selection strategy for jbfuzz (#171).** New opt-in seed
+  selector via metadata `selection=mcts_explore`, alongside the unchanged
+  default `ucb1_restart`. Builds a Monte-Carlo search tree (each node a prompt,
+  children its mutated variants) with a UCT tree policy — exploitation plus a
+  depth-weighted exploration bonus — progressive widening, and reward
+  backpropagation from each expanded leaf to the root, per GPTFuzzer (Yu et al.,
+  USENIX Security 2024). Deterministic under a fixed `rng_seed`. The result
+  records `selection` and `node_count`. Selection is now behind a `selector`
+  abstraction; UCB1+restart behavior (and RNG call order) is preserved exactly.
 - **Embedding-fitness for jbfuzz / persona_evolve (#170).** The evolutionary
   engines' opt-in `fitness=embedding` scorer is now implemented (was a stub
   returning "not implemented"). It scores goal-relevance as the cosine

--- a/src/attacks/adaptive/jbfuzz.go
+++ b/src/attacks/adaptive/jbfuzz.go
@@ -125,11 +125,20 @@ func (m *JBFuzzModule) Execute(
 		return skipped(common.SkipPreconditionFailed, fmt.Sprintf("no seeds found in %q", seedDir)), nil
 	}
 
-	// 5. Population — deterministic RNG when seeded via metadata "rng_seed",
-	//    otherwise time-based. Used by mutation and UCB1 random restart.
+	// 5. Selection strategy + RNG. Deterministic RNG when seeded via metadata
+	//    "rng_seed", otherwise time-based; used by mutation and selection.
+	//    Default selection is UCB1+restart (unchanged from v0.9.0); opt into the
+	//    MCTS-Explore tree via metadata "selection=mcts_explore" (#171).
 	rng := newRNG(config.Metadata["rng_seed"])
 
-	pool := newPopulation(seeds)
+	selectionName := config.Metadata["selection"]
+	if selectionName == "" {
+		selectionName = "ucb1_restart"
+	}
+	sel, err := newSelector(selectionName, seeds)
+	if err != nil {
+		return skipped(common.SkipPreconditionFailed, err.Error()), nil
+	}
 
 	// Indicators for "this looks harmful" (used by refusal-heuristic fitness):
 	// operator-supplied config.SuccessIndicators take precedence; seed
@@ -168,22 +177,14 @@ func (m *JBFuzzModule) Execute(
 			return skipped(common.SkipProviderError, fmt.Sprintf("ctx: %v", ctxErr)), nil
 		}
 
-		// Select a candidate by UCB1; every popRestartEvery iterations,
-		// substitute a uniform-random sample to escape local optima.
-		var cand candidate
-		if gen > 0 && gen%popRestartEvery == 0 {
-			cand = pool.uniformRandom(rng)
-		} else {
-			cand = pool.selectUCB1(gen)
-		}
-
-		// Mutate the candidate's prompt with one of the v0.9.0 operators.
-		mutator := pickMutator(rng)
-		mutated := mutator.apply(cand.prompt, rng)
+		// Select + expand via the configured strategy (UCB1+restart or
+		// MCTS-Explore). The selector owns mutation so it can record the mutated
+		// prompt as a tree node (MCTS) or score it against its seed (UCB1).
+		pick := sel.next(gen, rng)
 
 		// Query the target.
 		response, qerr := provider.Query(ctx, []common.Message{
-			{Role: "user", Content: mutated},
+			{Role: "user", Content: pick.prompt},
 		}, nil)
 		queries++
 
@@ -192,22 +193,20 @@ func (m *JBFuzzModule) Execute(
 		var score float64
 		if qerr == nil {
 			score = fit.score(response, successInds)
-		} else {
-			score = 0.0
 		}
-		pool.update(cand.id, score)
+		sel.record(pick, score)
 
 		trajectory = append(trajectory, generationSummary{
-			Generation: gen,
-			CandidateID: cand.id,
-			Mutator:    mutator.name(),
-			Score:      score,
-			Queries:    queries,
+			Generation:  gen,
+			CandidateID: pick.candidateID,
+			Mutator:     pick.mutatorName,
+			Score:       score,
+			Queries:     queries,
 		})
 
 		if score > bestScore {
 			bestScore = score
-			bestCandidate = mutated
+			bestCandidate = pick.prompt
 			bestResponse = response
 		}
 
@@ -246,6 +245,8 @@ func (m *JBFuzzModule) Execute(
 	result.Metadata["best_score"] = bestScore
 	result.Metadata["fitness"] = fitnessName
 	result.Metadata["population_size"] = len(seeds)
+	result.Metadata["selection"] = selectionName
+	result.Metadata["node_count"] = sel.nodeCount()
 	result.Metadata["population_trajectory"] = trajectory
 	if len(clamped) > 0 {
 		result.Metadata["budget_clamped"] = clamped
@@ -334,6 +335,185 @@ func (p *population) update(id string, score float64) {
 			return
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Selection strategies (#171)
+// ---------------------------------------------------------------------------
+
+// pick is what a selector hands back each generation: the mutated prompt to
+// query, trajectory bookkeeping, and an opaque handle the selector uses to
+// apply the score (a candidate id for UCB1, a *mctsNode for MCTS).
+type pick struct {
+	prompt      string
+	mutatorName string
+	candidateID string
+	handle      interface{}
+}
+
+// selector abstracts seed/node selection so the main loop is strategy-agnostic.
+type selector interface {
+	// next selects and mutates, returning the prompt to query this generation.
+	next(gen int, rng *rand.Rand) pick
+	// record applies the score for a previously returned pick.
+	record(p pick, score float64)
+	// nodeCount is the number of seeds/nodes the strategy is tracking.
+	nodeCount() int
+}
+
+func newSelector(name string, seeds []seed) (selector, error) {
+	switch name {
+	case "", "ucb1_restart":
+		return &ucb1RestartSelector{pool: newPopulation(seeds)}, nil
+	case "mcts_explore":
+		return newMCTSSelector(seeds), nil
+	default:
+		return nil, fmt.Errorf("jbfuzz: unknown selection %q (valid: ucb1_restart, mcts_explore)", name)
+	}
+}
+
+// ucb1RestartSelector is the v0.9.0 default: UCB1 over a fixed seed population
+// with a periodic uniform-random restart. Behavior (and RNG call order) is
+// unchanged from the pre-#171 inline loop.
+type ucb1RestartSelector struct {
+	pool *population
+}
+
+func (s *ucb1RestartSelector) next(gen int, rng *rand.Rand) pick {
+	var cand candidate
+	if gen > 0 && gen%popRestartEvery == 0 {
+		cand = s.pool.uniformRandom(rng)
+	} else {
+		cand = s.pool.selectUCB1(gen)
+	}
+	mut := pickMutator(rng)
+	return pick{
+		prompt:      mut.apply(cand.prompt, rng),
+		mutatorName: mut.name(),
+		candidateID: cand.id,
+		handle:      cand.id,
+	}
+}
+
+func (s *ucb1RestartSelector) record(p pick, score float64) {
+	if id, ok := p.handle.(string); ok {
+		s.pool.update(id, score)
+	}
+}
+
+func (s *ucb1RestartSelector) nodeCount() int { return len(s.pool.candidates) }
+
+// ---------------------------------------------------------------------------
+// MCTS-Explore (#171) — GPTFuzzer (Yu et al., USENIX Security 2024)
+// ---------------------------------------------------------------------------
+
+const (
+	// mctsExploreConstant: UCT exploration weight, classic c=sqrt(2).
+	mctsExploreConstant = 1.41421356237
+	// mctsDepthPenalty: the explore bonus is weighted by depth — deeper nodes
+	// are penalized so the search keeps breadth and doesn't tunnel into one
+	// over-mutated lineage (GPTFuzzer's reward-for-depth correction).
+	mctsDepthPenalty = 0.1
+	// mctsMaxChildren: progressive widening — a node accumulates up to this many
+	// children before the tree policy is forced to descend instead of expand.
+	mctsMaxChildren = 4
+)
+
+type mctsNode struct {
+	id         string
+	prompt     string
+	depth      int
+	parent     *mctsNode
+	children   []*mctsNode
+	totalScore float64
+	visits     int
+}
+
+// uct scores a node for the tree policy. Unvisited nodes return +Inf so they
+// are always expanded first; otherwise exploitation (mean reward) plus a
+// depth-weighted exploration bonus.
+func (n *mctsNode) uct(parentVisits int) float64 {
+	if n.visits == 0 {
+		return math.MaxFloat64
+	}
+	avg := n.totalScore / float64(n.visits)
+	explore := mctsExploreConstant * math.Sqrt(math.Log(float64(parentVisits+1))/float64(n.visits))
+	return avg + explore - mctsDepthPenalty*float64(n.depth)
+}
+
+type mctsSelector struct {
+	roots  []*mctsNode
+	all    []*mctsNode // flat index for nodeCount
+	nextID int
+}
+
+func newMCTSSelector(seeds []seed) *mctsSelector {
+	s := &mctsSelector{}
+	for _, sd := range seeds {
+		n := &mctsNode{id: sd.ID, prompt: sd.Prompt}
+		s.roots = append(s.roots, n)
+		s.all = append(s.all, n)
+	}
+	return s
+}
+
+func (s *mctsSelector) next(_ int, rng *rand.Rand) pick {
+	// Tree policy: best root, then descend by UCT until a node with room for
+	// another child (progressive widening), then expand there.
+	node := bestByUCT(s.roots, s.rootVisits())
+	for len(node.children) >= mctsMaxChildren {
+		node = bestByUCT(node.children, node.visits)
+	}
+
+	// Expansion: mutate the selected node's prompt into a fresh child node.
+	mut := pickMutator(rng)
+	s.nextID++
+	child := &mctsNode{
+		id:     fmt.Sprintf("mcts-%d", s.nextID),
+		prompt: mut.apply(node.prompt, rng),
+		depth:  node.depth + 1,
+		parent: node,
+	}
+	node.children = append(node.children, child)
+	s.all = append(s.all, child)
+
+	return pick{prompt: child.prompt, mutatorName: mut.name(), candidateID: child.id, handle: child}
+}
+
+// record backpropagates the score from the expanded leaf up to its root.
+func (s *mctsSelector) record(p pick, score float64) {
+	node, ok := p.handle.(*mctsNode)
+	if !ok {
+		return
+	}
+	for n := node; n != nil; n = n.parent {
+		n.totalScore += score
+		n.visits++
+	}
+}
+
+func (s *mctsSelector) nodeCount() int { return len(s.all) }
+
+func (s *mctsSelector) rootVisits() int {
+	total := 0
+	for _, r := range s.roots {
+		total += r.visits
+	}
+	return total
+}
+
+// bestByUCT returns the highest-UCT node among siblings (deterministic on ties:
+// first index wins, so a fixed rng_seed yields a reproducible tree).
+func bestByUCT(nodes []*mctsNode, parentVisits int) *mctsNode {
+	best := nodes[0]
+	bestUCT := best.uct(parentVisits)
+	for _, n := range nodes[1:] {
+		if u := n.uct(parentVisits); u > bestUCT {
+			bestUCT = u
+			best = n
+		}
+	}
+	return best
 }
 
 // ---------------------------------------------------------------------------

--- a/src/attacks/adaptive/mcts_test.go
+++ b/src/attacks/adaptive/mcts_test.go
@@ -1,0 +1,142 @@
+package adaptive
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/perplext/LLMrecon/src/attacks/common"
+	"github.com/perplext/LLMrecon/src/attacks/testutil"
+)
+
+func TestMCTS_TreeConstruction(t *testing.T) {
+	seeds := []seed{{ID: "s1", Prompt: "alpha prompt"}, {ID: "s2", Prompt: "beta prompt"}}
+	s := newMCTSSelector(seeds)
+
+	// Roots only, before any expansion.
+	if s.nodeCount() != 2 {
+		t.Fatalf("initial nodeCount = %d, want 2 (one per seed)", s.nodeCount())
+	}
+
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 10; i++ {
+		p := s.next(i, rng)
+		if p.prompt == "" || p.candidateID == "" {
+			t.Fatalf("expansion %d produced an empty pick: %+v", i, p)
+		}
+		s.record(p, 0.5)
+	}
+	// Each next() adds exactly one node.
+	if s.nodeCount() != 12 {
+		t.Fatalf("nodeCount after 10 expansions = %d, want 12", s.nodeCount())
+	}
+}
+
+func TestMCTS_UCT(t *testing.T) {
+	// Unvisited node is always prioritized.
+	if got := (&mctsNode{}).uct(5); got != math.MaxFloat64 {
+		t.Errorf("unvisited uct = %v, want +max", got)
+	}
+
+	// Visited node: avg + explore - depthPenalty*depth.
+	n := &mctsNode{visits: 2, totalScore: 1.0, depth: 3}
+	want := 0.5 + mctsExploreConstant*math.Sqrt(math.Log(11)/2) - mctsDepthPenalty*3
+	if got := n.uct(10); math.Abs(got-want) > 1e-9 {
+		t.Errorf("uct = %v, want %v", got, want)
+	}
+
+	// Deeper nodes score lower, all else equal (the depth penalty).
+	shallow := &mctsNode{visits: 1, totalScore: 0.5, depth: 1}
+	deep := &mctsNode{visits: 1, totalScore: 0.5, depth: 5}
+	if shallow.uct(10) <= deep.uct(10) {
+		t.Errorf("shallow (%v) should outscore deep (%v) at equal reward", shallow.uct(10), deep.uct(10))
+	}
+}
+
+func TestMCTS_BackpropUpdatesAncestors(t *testing.T) {
+	root := &mctsNode{id: "r", prompt: "r"}
+	child := &mctsNode{id: "c", prompt: "c", depth: 1, parent: root}
+	grand := &mctsNode{id: "g", prompt: "g", depth: 2, parent: child}
+	s := &mctsSelector{roots: []*mctsNode{root}, all: []*mctsNode{root, child, grand}}
+
+	s.record(pick{handle: grand}, 0.8)
+
+	// The leaf and every ancestor get one visit and the score.
+	for _, n := range []*mctsNode{grand, child, root} {
+		if n.visits != 1 || math.Abs(n.totalScore-0.8) > 1e-9 {
+			t.Errorf("node %s: visits=%d score=%f, want 1 / 0.8", n.id, n.visits, n.totalScore)
+		}
+	}
+
+	// A second backprop through the same chain accumulates.
+	s.record(pick{handle: grand}, 0.2)
+	if root.visits != 2 || math.Abs(root.totalScore-1.0) > 1e-9 {
+		t.Errorf("root after 2 backprops: visits=%d score=%f, want 2 / 1.0", root.visits, root.totalScore)
+	}
+}
+
+func mctsSmokeConfig(t *testing.T) common.AttackConfig {
+	cfg := gatedConfig(tmpSeedDir(t))
+	cfg.Metadata["selection"] = "mcts_explore"
+	cfg.Metadata["max_generations"] = "100"
+	cfg.Metadata["max_queries"] = "100"
+	cfg.Metadata["early_stop_on_success"] = "false"
+	return cfg
+}
+
+func TestExecute_MCTSExplore_BuildsTree(t *testing.T) {
+	m := &JBFuzzModule{}
+	// Refusal response keeps scores below threshold so the run uses its full
+	// generation budget (no early stop).
+	provider := &testutil.MockProvider{DefaultResponse: "I cannot help with that."}
+
+	r, err := m.Execute(context.Background(), provider, mctsSmokeConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Metadata["selection"] != "mcts_explore" {
+		t.Errorf("selection metadata = %v, want mcts_explore", r.Metadata["selection"])
+	}
+	nc, ok := r.Metadata["node_count"].(int)
+	if !ok || nc <= 10 {
+		t.Fatalf("node_count = %v, want a non-trivial tree (>10)", r.Metadata["node_count"])
+	}
+}
+
+func TestExecute_MCTSExplore_Deterministic(t *testing.T) {
+	m := &JBFuzzModule{}
+	provider := &testutil.MockProvider{DefaultResponse: "I cannot help with that."}
+
+	run := func() string {
+		r, err := m.Execute(context.Background(), provider, mctsSmokeConfig(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+		traj, err := json.Marshal(r.Metadata["population_trajectory"])
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(traj)
+	}
+
+	if a, b := run(), run(); a != b {
+		t.Error("identical rng_seed should produce an identical MCTS trajectory")
+	}
+}
+
+func TestExecute_UnknownSelectionReportsPreconditionFailed(t *testing.T) {
+	m := &JBFuzzModule{}
+	provider := &testutil.MockProvider{DefaultResponse: "ok"}
+	cfg := gatedConfig(tmpSeedDir(t))
+	cfg.Metadata["selection"] = "monte-carlo-beans"
+
+	r, err := m.Execute(context.Background(), provider, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.SkipReason != common.SkipPreconditionFailed {
+		t.Errorf("SkipReason = %q, want %q", r.SkipReason, common.SkipPreconditionFailed)
+	}
+}


### PR DESCRIPTION
## Summary

The final v0.12.0 feature. Adds an opt-in **MCTS-Explore** seed-selection strategy to `jbfuzz`, alongside the unchanged default UCB1+restart, behind a new `selector` abstraction. Per GPTFuzzer (Yu et al., USENIX Security 2024).

## Design

A `selector` interface (`next` / `record` / `nodeCount`) makes the main loop strategy-agnostic. The selector owns mutation so it can record a mutated prompt as a tree node (MCTS) or score it against its seed (UCB1).

- **`ucb1RestartSelector`** (default `selection=ucb1_restart`) wraps the existing population. Behavior **and RNG call order are unchanged** — no regression for v0.9.0 operators.
- **`mctsSelector`** (`selection=mcts_explore`): a Monte-Carlo tree where each node is a prompt and children are its mutated variants.
  - **Tree policy**: UCT = exploitation (mean reward) + exploration bonus, with a **depth penalty** so the search keeps breadth instead of tunneling into one over-mutated lineage. Unvisited nodes are prioritized.
  - **Progressive widening**: a node accumulates up to `mctsMaxChildren` before the policy is forced to descend.
  - **Backpropagation**: each expanded leaf's score propagates to the root.

## Acceptance (#171)
- [x] `selection=ucb1_restart` (default, unchanged) and `selection=mcts_explore` both work
- [x] Unit tests: tree construction, UCT formula, backpropagation
- [x] Smoke test: 100-generation run vs mock → non-trivial tree (>10 nodes)
- [x] Determinism preserved when `rng_seed` is set
- [x] CHANGELOG entry

Out of scope (per the issue): LLM-driven mutator — the synonym primary stays the default.

## Tests
tree construction (1 node/expansion); UCT formula + depth-penalty ordering; backprop up the ancestor chain (incl. accumulation); 100-gen smoke (`node_count > 10`); determinism (identical trajectory under same seed); unknown-selection → `SkipPreconditionFailed`. All green under `-race`.

Closes #171.

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9