### PR TITLE
docs: cover adaptive fuzzing engines + v0.12.0 attack additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This changelog was started with v0.9.0; earlier history lives in `git log`.
 
 ## [Unreleased]
 
+### Documentation
+
+- Documented the adaptive/evolutionary fuzzing engines (`jbfuzz`,
+  `persona_evolve`) in `docs/ATTACK_TECHNIQUES.md` — including the v0.12.0
+  `selection=mcts_explore` and `fitness=embedding` knobs and memory-poisoning
+  cleanup via `attack purge` / `Purger` — with research citations (JBFuzz,
+  GPTFuzzer, e5, MINJA/MemoryGraft/InjecMem). Added `attack purge` and the
+  engine metadata knobs to `docs/quickstart.md`.
+
 ## [0.12.0] - 2026-06-22
 
 Everything since v0.10.0: the v0.11.0 stabilization pass (first-time test

--- a/docs/ATTACK_TECHNIQUES.md
+++ b/docs/ATTACK_TECHNIQUES.md
@@ -1187,7 +1187,7 @@ Pre-built attack sequences for specific multi-agent frameworks (`templates/frame
 27. [Persona Evolution — arXiv 2507.22171](https://arxiv.org/abs/2507.22171)
 28. [MINJA: Memory Injection Attack — arXiv 2503.03704](https://arxiv.org/abs/2503.03704)
 29. [MemoryGraft — arXiv 2512.16962](https://arxiv.org/abs/2512.16962)
-30. [InjecMem — OpenReview QVX6hcJ2um](https://openreview.net/forum?id=QVX6hcJ2um)
+30. InjecMem — OpenReview `QVX6hcJ2um` (submission identifier per the source memory-poisoning module; not linked — a resolvable OpenReview URL could not be confirmed at publication time)
 
 ---
 

--- a/docs/ATTACK_TECHNIQUES.md
+++ b/docs/ATTACK_TECHNIQUES.md
@@ -934,6 +934,78 @@ The following sections document novel attack techniques from recent security res
 
 ---
 
+### Evolutionary Fuzzing Engines
+
+Black-box engines that *discover* jailbreaks at runtime by mutating a seed corpus and steering on feedback — distinct from the curated, handcrafted techniques above. Both require `allow_experimental=true` (they generate novel attacks rather than replaying known ones) and share pluggable **fitness** scorers; JBFuzz additionally exposes pluggable **selection** strategies.
+
+#### JBFuzz
+
+**Description**: Black-box mutation/feedback fuzzer using synonym substitution over a seed corpus. Each generation selects a seed, mutates it, queries the target, and scores the response; higher-scoring seeds are favored over time.
+
+**Technique IDs**: `jbfuzz`
+
+**OWASP Mapping**: LLM01, ASI01
+
+**Source**: JBFuzz — arXiv 2503.08990
+
+**Selection strategies** (`metadata selection=`):
+- `ucb1_restart` *(default)* — UCB1 bandit over the fixed seed population with a periodic uniform-random restart to escape local optima.
+- `mcts_explore` — Monte-Carlo search tree: each node is a prompt, children are its mutated variants; a UCT tree policy (exploitation + depth-weighted exploration bonus) with progressive widening and reward backpropagation from each expanded leaf to the root. Per GPTFuzzer (Yu et al., USENIX Security 2024, arXiv 2309.10253).
+
+**Fitness scorers** (`metadata fitness=`):
+- `heuristic` *(default)* — refusal-indicator matching with a short-response length floor. Cheap, deterministic, no dependencies.
+- `embedding` — scores goal-relevance as the cosine similarity between the target response and the operator `objective`, embedded via a local Ollama-style endpoint (`embedding_endpoint`, default `http://localhost:11434/api/embeddings`; `embedding_model`, default `nomic-embed-text`), blended with the heuristic. Opting in without a reachable endpoint yields a clean `Skipped`/`precondition_failed`, never a crash. Per e5-base-v2 (arXiv 2212.03533).
+
+**Key metadata**: `allow_experimental=true` (required), `selection`, `fitness`, `seed_dir`, `rng_seed` (deterministic runs), `max_queries` / `max_generations` / `max_wall_clock_seconds` (budget, hard-capped), `early_stop_on_success`.
+
+**Success Indicators**:
+- A mutated prompt elicits a response crossing the fitness success threshold
+- Result records `selection`, `node_count`, `best_score`, and the per-generation trajectory
+
+#### Persona Evolution
+
+**Description**: Genetic algorithm that evolves jailbreak *personas* (backstory / traits / style) via uniform crossover and mutation, with k-tournament selection and a novelty penalty that preserves population diversity. Shares JBFuzz's fitness scorers (`heuristic` / `embedding`).
+
+**Technique IDs**: `persona_evolve`
+
+**OWASP Mapping**: LLM01, ASI01, ASI09
+
+**Source**: arXiv 2507.22171
+
+**Key metadata**: `allow_experimental=true` (required), `fitness`, `corpus_path`, `rng_seed`, and the same budget knobs as JBFuzz.
+
+**Success Indicators**:
+- An evolved persona elicits a response crossing the fitness threshold
+
+---
+
+### Memory Poisoning & Cleanup
+
+**Description**: Persistent, state-changing attacks that inject a payload into a target's long-term memory store (vector DB / agent log) so it resurfaces in a later turn or session. All modes require `i_understand_risks=true` and a target that retains memory (`common.MemoryProbe`); they fail-fast as `Skipped` against stateless targets.
+
+**Technique IDs**: `minja`, `memorygraft`, `injecmem`
+
+**OWASP Mapping**: ASI06 (memorygraft also ASI10)
+
+**Sources**: MINJA — arXiv 2503.03704 · MemoryGraft — arXiv 2512.16962 · InjecMem — OpenReview QVX6hcJ2um
+
+**Cleanup (`attack purge`)**: every run records the injected record IDs (`metadata injected_record_ids`, also echoed in `CleanupHint`) and whether the target supports automated cleanup (`purger_available`). When the provider implements the `common.Purger` capability, roll the injection back with:
+
+```bash
+# explicit IDs
+llmrecon attack purge --provider=<name> --record-ids=rec-1,rec-2
+# or read IDs from a prior run's --emit-jsonl output
+llmrecon attack purge --provider=<name> --result=run.jsonl
+```
+
+Providers without `Purger` return a friendly error pointing back to the manual `CleanupHint`.
+
+**Success Indicators**:
+- The injected payload resurfaces in a later turn/session (poisoning landed)
+- After `purge`, the implant is absent from the store
+
+---
+
 ### Data Exfiltration
 
 #### Covert Channel Exfiltration
@@ -1109,6 +1181,13 @@ Pre-built attack sequences for specific multi-agent frameworks (`templates/frame
 21. [Columbia University — Browser Agent Security (2025)](https://arxiv.org/abs/2501.xxxxx)
 22. [Kaspersky OpenClaw Analysis — Skill Takeover Chains (2026)](https://securelist.com/openclaw-analysis/)
 23. [Cubic Security Audit — Agent RCE Chains (2026)](https://cubic.dev/security-audit-2026)
+24. [JBFuzz — arXiv 2503.08990](https://arxiv.org/abs/2503.08990)
+25. [GPTFuzzer (MCTS-Explore) — Yu et al., USENIX Security 2024, arXiv 2309.10253](https://arxiv.org/abs/2309.10253)
+26. [Text Embeddings by Weakly-Supervised Contrastive Pre-training (e5) — arXiv 2212.03533](https://arxiv.org/abs/2212.03533)
+27. [Persona Evolution — arXiv 2507.22171](https://arxiv.org/abs/2507.22171)
+28. [MINJA: Memory Injection Attack — arXiv 2503.03704](https://arxiv.org/abs/2503.03704)
+29. [MemoryGraft — arXiv 2512.16962](https://arxiv.org/abs/2512.16962)
+30. [InjecMem — OpenReview QVX6hcJ2um](https://openreview.net/forum?id=QVX6hcJ2um)
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,6 +62,11 @@ Useful flags (`./llmrecon attack run --help` for the full list):
 - `--emit-jsonl <path>` — append the result as one JSON line for the Python
   ingest pipeline (`python -m ml.data.ingest`).
 
+The evolutionary engines (`jbfuzz`, `persona_evolve`) take extra `--metadata`
+knobs — `selection=ucb1_restart|mcts_explore`, `fitness=heuristic|embedding`
+(with `embedding_endpoint` / `embedding_model`), and `rng_seed` for
+deterministic runs. See [Attack Techniques](ATTACK_TECHNIQUES.md#evolutionary-fuzzing-engines).
+
 ## 4. Run against a real provider
 
 Real providers read the API key from `--api-key` (preferred) or the
@@ -76,6 +81,18 @@ Real providers read the API key from `--api-key` (preferred) or the
 export OPENAI_API_KEY="sk-..."
 ./llmrecon attack run --module=jbfuzz --provider=openai --payload="..." \
   --metadata=allow_experimental=true
+```
+
+### Cleaning up memory-poisoning implants
+
+The memory-poisoning modules (`minja`, `memorygraft`, `injecmem`) record the
+injected record IDs in their result. When the target supports automated cleanup,
+roll an injection back with `attack purge`:
+
+```bash
+./llmrecon attack purge --provider=<name> --record-ids=rec-1,rec-2
+# or read the IDs from a prior run's --emit-jsonl output
+./llmrecon attack purge --provider=<name> --result=run.jsonl
 ```
 
 ## 5. Templates

--- a/src/cmd/readme_smoke_test.go
+++ b/src/cmd/readme_smoke_test.go
@@ -108,6 +108,7 @@ func TestQuickstartDocumentsRealCLISurface(t *testing.T) {
 	cases := []string{
 		"attack list",
 		"attack run",
+		"attack purge",
 		"template list",
 		"template create",
 		"bundle create",


### PR DESCRIPTION
## Summary

Closes the documentation/research-coverage gap for the adaptive engines and this session's v0.12.0 additions. `docs/ATTACK_TECHNIQUES.md` (the technique catalog) never documented the `jbfuzz`/`persona_evolve` engines at all, nor the new selection/fitness knobs or `attack purge`.

## Changes

**`docs/ATTACK_TECHNIQUES.md`**
- New **Evolutionary Fuzzing Engines** section:
  - **JBFuzz** (arXiv 2503.08990) — selection strategies `ucb1_restart` (default) / `mcts_explore` (#171, GPTFuzzer arXiv 2309.10253); fitness scorers `heuristic` (default) / `embedding` (#170, e5 arXiv 2212.03533); full metadata knobs.
  - **Persona Evolution** (arXiv 2507.22171) — genetic persona evolution sharing the fitness scorers.
- New **Memory Poisoning & Cleanup** section — `minja`/`memorygraft`/`injecmem` (arXiv 2503.03704 / 2512.16962 / OpenReview) and the new `attack purge` / `Purger` cleanup flow (#168).
- 7 new entries in the References list.

**`docs/quickstart.md`**
- Documented `attack purge` (with both `--record-ids` and `--result` forms) and the engine `--metadata` knobs (`selection`, `fitness`, `embedding_endpoint`, `rng_seed`), linking to the catalog.

**`src/cmd/readme_smoke_test.go`**
- `TestQuickstartDocumentsRealCLISurface` now also guards `attack purge` (every command in the quickstart must resolve via `rootCmd.Find`).

## Notes
- Research references previously lived only in code comments + the CHANGELOG; this surfaces them for users/researchers.
- Post-v0.12.0-tag doc improvement → tracked under `[Unreleased]`.

## Verification
- `go vet ./src/cmd/` clean; quickstart smoke test green (incl. the new `attack purge`).

https://claude.ai/code/session_01Jw4x9Xhv1HwDwuEF2gZYd9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for adaptive and evolutionary fuzzing engines with strategy and fitness configuration details
  * Added comprehensive attack techniques guide covering JBFuzz and Persona Evolution approaches
  * Included memory poisoning and cleanup workflow documentation with record management guidance
  * Enhanced quickstart guide with additional metadata parameters for deterministic behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->